### PR TITLE
Update revo-to-full-manual.txt

### DIFF
--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -9,7 +9,7 @@
       • Full manual offers more control over what abilities are used, when they are used, and how they are used.
 .
 
-> __**Revo vs. Full Manual**__
+> __**Why You Should Switch to Full Manual: A Comparison Between Revo and Full Manual**__
 .tag:comparison
 ⬥ **__Channeled abilities__**
       • Usually last longer than a Global Cooldown (3 ticks or 1.8s).
@@ -55,30 +55,32 @@
           - Strong melee attack. A common strategy to deal with the mechanic is to Resonance it to heal some health back. Requires precise timing and manual input.
 .
 
-> **More advanced scenarios:**
-What if I use revolution but I manually activate basics most of the time? What benefit will full manual provide at that point?
-This is a really good point and at this stage, there’s very minute things that full manual can offer to aid you in combat. Most of the examples below will relate to auto attacks. Revolution inherently does not interact smoothly with auto attacks unlike full manual.
+⬥ __**Revo with mostly manual inputs**__
+      • There is not much difference between using full manual without revo vs. full manual with revo as a backup.
+          - The biggest difference between the two is without revo you have insurance that you will never use an ability that you didnt mean to use.
+          - Auto attacks do not work well with revo. For example with magic if you wish to utilize 4TAA, you need to input the auto attack once to cancel your next revo input. and again to actually fire the auto attack.
+
+⬥ **__5 tick auto attack (5TAA)__**
+      • Melee and Range cannot utilize 5TAA because there is no "auto" button like mage has with casting a spell to stop the next ability from happening.
+      • 5TAA can normally be used instead of a weaker ability if the better abilities happen to be on cooldown at the same time.
 .
-_ _
-> **High Input Revo vs. Full Manual**
-__4 tick auto attack:__ 
 
-Self explanatory. Undoubtably the biggest reason why many users prefer full manual over Revo (4taa is roughly a 7% dps increase when done well). Revo requires 2x input per every auto attack. One input to make your character stop attacking after gcd and a 2nd input to initiate the auto attack on the 4th tick. Auto attacks happen on every 7 ticks; do the math for a 5 minute boss encounter and that’s a lot of extra input you have to do if you’re attempting to 4taa on Revo. 
-
-__Auto weaving in defensives:__
-
-When using an ability that does not do damage, sometimes an auto attack will occur during gcd and provide an extra source of damage. Abilities such as Sunshine, Death Swiftness, Berzerk, Resonance, Anticipate, Freedom, Preperation, Reflect, Revenge, Provoke on gcd, Natural Instinct, Eldrich Special Attack (any ability that incurs a gcd but does not deal damage) are all examples of where this happens. Sometimes these auto attacks are purposely used to a) gain extra damage, and b) gain extra adrenaline. Using revolution, it is much more difficult to weave in an auto attack during gcd as inputting an auto-spell will halt any ability casting. Revo users will have to manually input an ability after the auto-spell to start revo again. Full manual users would just need to input an auto-spell during gcd and continue on in their rotation normally. 
-
-__5 tick auto attack__
-
-Similar to 4taa, 5 tick auto attack is used in Melee and Range rotations in substitution of an 100% damaging ability. An auto attack in Melee and Range deal an average of 130% ability damage, thus is better than a slice or a piercing shot basic ability. In dps-reliant phases, a 5taa can be used instead of a weaker basic ability as the 5taa is more damage. Revo users cannot do 5taa as there is no auto attack button for melee/range.
-.
-_ _
-> **Positioning:**
-On Revo, clicking underneath your character will not stop you deactivating revo. On full manual, clicking underneath your character will stop you from attacking (will stop auto attacks too). While it may seem small, staying on a particular square is important in certain boss mechanics. Examples include but not limited to: 
--    Vorago p5, dpsers must stay on the South wall
--    Vorago base, must keep Vorago in base spot for convenience
--    Vorago green bomb in 5 man teams, must form a square between 3 other players and stay in formation
--    Aod base, must keep her in the center of the arena for chinner and minions on p2 and p3.
-
-**Final thoughts**: This is just a reminder that Full Manual is not needed to be proficient at pvm or bossing at all. You can do raids, Telos, duo Vorago, duo Solak, 7man Aod, etc using Revo and many players already do. However, if you’re looking to up your combat capabilities and squeeze in some more dps, full manual offers a range of benefits listed above that revo just cannot replicate.
+> **__How to Transition from Revo to Full Manual__**
+.tag:transition
+⬥ Set good keybinds.
+      • It is very important to have keybinds that are comfortable to reach and make sense to you.
+      • It is up to the user to decide what keybinds make sense to them, but there is a video guide full of helpful suggestions here made by <@158292421724209152>: <https://www.youtube.com/watch?v=zn_y-_2giZg>
+      
+⬥ Practice the keybinds.
+      • Spend time at combat dummies just getting used to the keybinds, and commit them to muscle memory. Your goal is to not need to think about what keybind does what ability. You should know what ability you want to do, and the muscle memory should do the rest for you.
+      • Another good place to practice is God Wars Dungeon 2 due to how it has low death potential and can earn you some money as you practice the new keybinds. 
+      
+⬥ Choose a gradual transition or fully commit to full manual right away.
+      • Some players find it easier to start easing into full manual by keeping revo active as a backup, but using more and more manual inputs until they feel confident enough to turn revo off.
+      • Some players find it easer to rip the bandaid off and just turn off revo, then practice their keybinds over and over until they are confident enough to use full manual in real PvM scenarios.
+          - Again, it is up to the user to decide what works best for them.
+          
+> **__Table of Contents__**
+⬥ **Introduction** - $linkmsg_intro$
+⬥ **Why You Should Switch to Full Manual** - $linkmsg_comparison$
+⬥ **How to Transition from Revo to Full Manual** - $linkmsg_transition$

--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -79,7 +79,8 @@ https://i.imgur.com/Y6XWNaF.jpg
       • Some players find it easier to start easing into full manual by keeping revo active as a backup, but using more and more manual inputs until they feel confident enough to turn revo off.
       • Some players find it easer to rip the bandaid off and just turn off revo, then practice their keybinds over and over until they are confident enough to use full manual in real PvM scenarios.
           - Again, it is up to the user to decide what works best for them.
-          
+.
+
 > **__Table of Contents__**
 ⬥ **Introduction** - $linkmsg_intro$
 ⬥ **Why You Should Switch to Full Manual** - $linkmsg_comparison$

--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -69,7 +69,7 @@ https://i.imgur.com/Y6XWNaF.jpg
 .tag:transition
 ⬥ Set good keybinds.
       • It is very important to have keybinds that are comfortable to reach and make sense to you.
-      • It is up to the user to decide what keybinds make sense to them, but there is a video guide full of helpful suggestions here made by <@158292421724209152>: <https://www.youtube.com/watch?v=zn_y-_2giZg>
+      • It is up to the user to decide what keybinds make sense to them, but there is a video guide full of helpful suggestions here made by <@158292421724209152>: https://www.youtube.com/watch?v=zn_y-_2giZg
       
 ⬥ Practice the keybinds.
       • Spend time at combat dummies just getting used to the keybinds, and commit them to muscle memory. Your goal is to not need to think about what keybind does what ability. You should know what ability you want to do, and the muscle memory should do the rest for you.

--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -40,18 +40,18 @@ https://i.imgur.com/Y6XWNaF.jpg
 
 ⬥ **__Boss Mechanics__**
 ⬥ As you progress in pvm and face tougher and tougher bosses, you will encounter bosses with mechanics where revolution could greatly hinder your combat ability. Here are a few scenarios where revolution could cause more harm than good:
-      • Arraxor: Web Shield mechanic 
+      • __Arraxor:__ Web Shield mechanic 
           - Player must manually input to stop attacking, otherwise all damage gets reflected onto the player potentially causing a KO
-      • Vorago: Reflect mechanic
+      • __Vorago:__ Reflect mechanic
           - Damage gets reflected onto a player and revo requires a manual input to stop attacking
-      • Telos: Hold Still Invader
+      • __Telos:__ Hold Still Invader
           - This mechanic is commonly dealt with by switching to a shield and using Resonance. This does require precise timings and if you are on revo, there is a chance that revo activates an ability while you are waiting to Resonance. This activates the Global Cooldown and you are unable to use Resonance in time.
-      • Kalphite King: Beetlejuice (Green)
+      • __Kalphite King:__ Beetlejuice (Green)
           - This mechanic requires provoking KK then either using Devotion or Resonance to negate/heal from the large hit. If using Resonance it requires precise timing.
-      • Nex: Blood Siphon and Blood Phase
+      • __Nex:__ Blood Siphon and Blood Phase
           - Any attacks during Blood Siphon will heal Nex rather than hurt her. This requires manual input to stop attacking during the special attack.
           - Blood phase has a mechanic where bleeds (Fragmentation Shot, Corruption Shot, etc.) will heal her instead of hurt her. Requires manual input to avoid using bleeds.
-      • Helwyr: Swipe Attack
+      • __Helwyr:__ Swipe Attack
           - Strong melee attack. A common strategy to deal with the mechanic is to Resonance it to heal some health back. Requires precise timing and manual input.
 .
 

--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -19,7 +19,7 @@
 
 ⬥ Below is a comparison of manually canceling a channeled ability vs just letting revo do it for you. Top version will let revo cancel Snipe for them, with no manual input at all. The bottom version will manually cancel the Snipe ability to initiate the next ability quicker. Notice how long the top player just stands idle after the Snipe.
       • **Note:** manually canceling channeled abilities can be done on revolution mode. But, it still requires a manual input from the player with precise timing.
-.img:https://i.imgur.com/6uH4KVg.gifv
+https://i.imgur.com/6uH4KVg.gifv
 
 .
 ⬥ **__Ultimate abilities__**
@@ -33,7 +33,7 @@
           - Bleed usage can be easily avoided in damage boosting ultimates since you can just choose to not input any bleed abilities.
 
 ⬥ The below gif will demonstrate how revo can make someone use bad abilities in a damage boosting ultimate (take a look at what abilities were used right after sunshine).
-.img:https://i.imgur.com/Y6XWNaF.jpg
+https://i.imgur.com/Y6XWNaF.jpg
 
       • Using full manual, this person would have been able to plan out what abilities are used prior to activating Sunshine. They can choose to use bleeds such as Corruption Blast or Combust, or they can choose to use a weaker ability such as Tuska’s Wrath right before Sunshine to make sure the good abilities like Dragon Breath and Impact (Flanking) are off cooldown and ready to use in Sunshine.
 .

--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -1,21 +1,29 @@
-> **Why switch from Revolution to Full Manual?**
-Let’s start from the beginning. The revolution combat mode allows the game to automatically activate abilities on your ability bar in a sequential order. There are three modes to revolution: only basics, basics and thresholds, or basics and thresholds and ultimates. The first option is what is generally referred to as ‘revolution’ whereas the latter two are referred to as ‘revo++’.
-Full manual is a combat mode where the game does not activate any abilities for you. Every ability you want to use in combat will require an input from the player. With no inputs from the player, full manual combat mode will only use auto attacks (sword swipes when using melee, arrows from your ammunition when ranging, auto-spells when using magic). 
-For a player just getting into pvm or bossing it is perfectly fine to use revolution. There are helpful guides and ability bar set ups on the official RS Wiki that make revolution viable in combat. **For most combat situations and scenarios, revolution is good enough.**
-
-But…
-Full manual exists for a reason and are there for players who are looking to get a little more out of their combat capabilities. In this FAQ, I will go over several reasons and scenarios where full manual is a *better* combat mode.
+> __**Introduction**__
+.tag:intro
+⬥ The revolution combat mode allows the game to automatically activate abilities on your ability bar in a sequential order. There are three modes to revolution: only basics (revo), basics and thresholds (revo+), or basics and thresholds and ultimates (revo++).
+      • For a player just getting into pvm or bossing it is perfectly fine to use revolution. 
+      • There are helpful guides and ability bar set ups on the official RS Wiki that make revolution viable in combat. 
+      • For most combat situations and scenarios, revolution is good enough.
+⬥ Full manual is a combat mode where the game does not activate any abilities for you. Every ability you want to use in combat will require an input from the player. 
+      • With no inputs from the player, full manual combat mode will only use auto attacks
+      • Full manual offers more control over what abilities are used, when they are used, and how they are used
 .
-_ _
-> **Revo vs. FM: Canceling channeled abilities**
-Lets look at channeled abilities. These abilities are different from regular abilities as they typically last longer than the global cooldown. A global cooldown is 3 ticks and is inherently tied to all abilities. A channeled ability will last anywhere from 4 to 11 ticks, or even longer in some cases. For most channeled abilities, there is an ending lag to the ability that can be manually canceled to start the next ability faster. Manually canceling the ending lag, as the name implies, requires a manual input from the player and will not be done automatically by revolution.
-Take a look at the gif below. Revolution is enabled on both versions. The above player will just let revolution do its thing, no manual input at all. The below player will manually cancel the Snipe ability to initiate the next ability quicker. Notice how long the top player just stands idle after the Snipe? 
 
-https://i.imgur.com/6uH4KVg.gifv
+> __**Revo vs. Full Manual**__
+.tag:comparison
+⬥ Channeled abilities
+      • usually last longer than a global cooldown (3 ticks or 1.8s)
+      • have an extra delay between the last hit of the ability and the start of the next ability
+          - This delay can be negated by manually inputting the next ability
+          - Revolution will let the delay run it's course which wastes time and damage
 
-Now, manually canceling channeled abilities can be done on revolution mode. But, it still requires a manual input from the player with precise timing.
+⬥ Below is a comparison of manually canceling a channeled ability vs just letting revo do it for you. Top version will let revo cancel Snipe for them, with no manual input at all. The bottom version will manually cancel the Snipe ability to initiate the next ability quicker. Notice how long the top player just stands idle after the Snipe
+
+<https://i.imgur.com/6uH4KVg.gifv>
+
+      • **Note:** manually canceling channeled abilities can be done on revolution mode. But, it still requires a manual input from the player with precise timing.
 .
-> **Revo vs. FM: Ultimates**
+⬥ Ultimate abilities
 Assuming your revolution is set to only activate basics, you will have to manually activate an ultimate ability such as Sunshine, Death Swiftness, or Berzerk. Now, both revolution and full manual will have to manually input activating an ultimate but the difference is what abilities are used leading up to the ultimate. Keep in mind that in the revolution scenario, there are no player inputs besides activating the ultimate ability. In the full manual scenario, every ability is chosen and inputted from the player.
 In a typical revolution bar, the really powerful abilities are placed first so that they’re used more often. This means that when building up to 100% adren, you have no control over what abilities are on cooldown prior to activating Sun. In sunshine, since all damage is boosted by 50%, you want to save the really powerful abilities till after you activate sunshine. Basics like Sonic Wave, Dragon Breath, and Impact-Flanking. Since the good abilities are placed first on your bar, revolution tends to activate them often and keep them on cooldown. This is a good thing normally, but you can find yourself in a scenario where all the powerful abilities are on cooldown right after you activate sunshine. The below gif will demonstrate such (take a look at what abilities were used right after sunshine).
 

--- a/getting-started/revo-to-full-manual.txt
+++ b/getting-started/revo-to-full-manual.txt
@@ -5,50 +5,56 @@
       • There are helpful guides and ability bar set ups on the official RS Wiki that make revolution viable in combat. 
       • For most combat situations and scenarios, revolution is good enough.
 ⬥ Full manual is a combat mode where the game does not activate any abilities for you. Every ability you want to use in combat will require an input from the player. 
-      • With no inputs from the player, full manual combat mode will only use auto attacks
-      • Full manual offers more control over what abilities are used, when they are used, and how they are used
+      • With no inputs from the player, full manual combat mode will only use auto attacks.
+      • Full manual offers more control over what abilities are used, when they are used, and how they are used.
 .
 
 > __**Revo vs. Full Manual**__
 .tag:comparison
-⬥ Channeled abilities
-      • usually last longer than a global cooldown (3 ticks or 1.8s)
-      • have an extra delay between the last hit of the ability and the start of the next ability
-          - This delay can be negated by manually inputting the next ability
-          - Revolution will let the delay run it's course which wastes time and damage
+⬥ **__Channeled abilities__**
+      • Usually last longer than a Global Cooldown (3 ticks or 1.8s).
+      • Have an extra delay between the last hit of the ability and the start of the next ability.
+          - This delay can be negated by manually inputting the next ability.
+          - Revolution will let the delay run it's course which wastes time and damage.
 
-⬥ Below is a comparison of manually canceling a channeled ability vs just letting revo do it for you. Top version will let revo cancel Snipe for them, with no manual input at all. The bottom version will manually cancel the Snipe ability to initiate the next ability quicker. Notice how long the top player just stands idle after the Snipe
-
-<https://i.imgur.com/6uH4KVg.gifv>
-
+⬥ Below is a comparison of manually canceling a channeled ability vs just letting revo do it for you. Top version will let revo cancel Snipe for them, with no manual input at all. The bottom version will manually cancel the Snipe ability to initiate the next ability quicker. Notice how long the top player just stands idle after the Snipe.
       • **Note:** manually canceling channeled abilities can be done on revolution mode. But, it still requires a manual input from the player with precise timing.
-.
-⬥ Ultimate abilities
-Assuming your revolution is set to only activate basics, you will have to manually activate an ultimate ability such as Sunshine, Death Swiftness, or Berzerk. Now, both revolution and full manual will have to manually input activating an ultimate but the difference is what abilities are used leading up to the ultimate. Keep in mind that in the revolution scenario, there are no player inputs besides activating the ultimate ability. In the full manual scenario, every ability is chosen and inputted from the player.
-In a typical revolution bar, the really powerful abilities are placed first so that they’re used more often. This means that when building up to 100% adren, you have no control over what abilities are on cooldown prior to activating Sun. In sunshine, since all damage is boosted by 50%, you want to save the really powerful abilities till after you activate sunshine. Basics like Sonic Wave, Dragon Breath, and Impact-Flanking. Since the good abilities are placed first on your bar, revolution tends to activate them often and keep them on cooldown. This is a good thing normally, but you can find yourself in a scenario where all the powerful abilities are on cooldown right after you activate sunshine. The below gif will demonstrate such (take a look at what abilities were used right after sunshine).
+.img:https://i.imgur.com/6uH4KVg.gifv
 
+.
+⬥ **__Ultimate abilities__**
+      • Should normally be used manually even if using revo (except afk slayer).
+      • Good revo bars will have the stronger abilities towards the beginning of the revo bar so they get activated more frequently.
+          - This is good for general use but detrimental for damage boosting ultimates like Sunshine/Death's Swiftness/Berserk.
+              • The best abilities will likely be on cooldown at the start of your damage boosting ult due to being at the front of the revo bar.
+              • Some of the best abilities are bleeds which will be near the front of the revo bar, but bleeds are NOT boosted by damage boosting ultimates.
+      • Full manual benefits a lot in damage boosting ultimates because you have full control of when you use the strong abilities.
+          - Strong abilities can be saved until you are within the damage boosting ultimate to get more use out of them.
+          - Bleed usage can be easily avoided in damage boosting ultimates since you can just choose to not input any bleed abilities.
+
+⬥ The below gif will demonstrate how revo can make someone use bad abilities in a damage boosting ultimate (take a look at what abilities were used right after sunshine).
 .img:https://i.imgur.com/Y6XWNaF.jpg
 
-Using full manual, you are better able to plan out what abilities are used prior to activating Sunshine. You can choose to use bleeds such as corruption blast or combust, or you can choose to use a weaker ability such as Tuska’s Wrath right before a sunshine to make sure the good abilities like Dragon Breath and Impact-Flanking are off cooldown and ready to use in Sunshine.
+      • Using full manual, this person would have been able to plan out what abilities are used prior to activating Sunshine. They can choose to use bleeds such as Corruption Blast or Combust, or they can choose to use a weaker ability such as Tuska’s Wrath right before Sunshine to make sure the good abilities like Dragon Breath and Impact (Flanking) are off cooldown and ready to use in Sunshine.
 .
-_ _
-> **Revo vs. Full Manual: Boss Mechanics**
-As you progress in pvm and face tougher and tougher bosses, you will encounter bosses where revolution could greatly hinder your combat ability. Here are a few scenarios where revolution could cause more harm than good:
-1)    __Arraxor__ – Web reflect mechanic 
-a.    Player must manually input to stop attacking, otherwise all damage gets reflected onto the player potentially causing a KO
-2)    __Vorago__ – Reflect mechanic
-a.    Same idea, damage gets reflected onto a player and revo requires a manual input to stop attacking
-3)    __Telos__ – Hold Still Invader
-a.    This mechanic is commonly dealt with by switching to a shield and using Resonance. This does require precise timings and if you are on revo, there’s a chance that revo activates an ability while you’re waiting to res. This puts you on global cooldown and suddenly, you are unable to activate any abilities while Telos smacks you silly.
-4)    __Kalphite King__ – Green 
-a.    This mechanic requires provoking KK then either using Devotion or Resonance to deal with the instant kill attack. If using resonance it requires precise timing to deal with the attack on-tick. 
-5)    __Nex__ – Blood Siphon and Blood Phase
-a.    Mechanic where any attacks during blood siphon will heal her rather than damage her. Requires manual input to stop attacking during the special attack.
-b.    Blood phase has a mechanic where any bleeds (combust, corruption blast, fragment shot, corruption shot, etc) will heal her instead of damaging her. Requires manual input to avoid using bleeds.
-6)    __Helwyr__ – Swipe attack
-a.    Mechanic where heavy melee damage will be dealt in a clearly visible melee attack. Common strategy to deal with the mechanic is to Resonance it. Requires precise timing and manual input.
+
+⬥ **__Boss Mechanics__**
+⬥ As you progress in pvm and face tougher and tougher bosses, you will encounter bosses with mechanics where revolution could greatly hinder your combat ability. Here are a few scenarios where revolution could cause more harm than good:
+      • Arraxor: Web Shield mechanic 
+          - Player must manually input to stop attacking, otherwise all damage gets reflected onto the player potentially causing a KO
+      • Vorago: Reflect mechanic
+          - Damage gets reflected onto a player and revo requires a manual input to stop attacking
+      • Telos: Hold Still Invader
+          - This mechanic is commonly dealt with by switching to a shield and using Resonance. This does require precise timings and if you are on revo, there is a chance that revo activates an ability while you are waiting to Resonance. This activates the Global Cooldown and you are unable to use Resonance in time.
+      • Kalphite King: Beetlejuice (Green)
+          - This mechanic requires provoking KK then either using Devotion or Resonance to negate/heal from the large hit. If using Resonance it requires precise timing.
+      • Nex: Blood Siphon and Blood Phase
+          - Any attacks during Blood Siphon will heal Nex rather than hurt her. This requires manual input to stop attacking during the special attack.
+          - Blood phase has a mechanic where bleeds (Fragmentation Shot, Corruption Shot, etc.) will heal her instead of hurt her. Requires manual input to avoid using bleeds.
+      • Helwyr: Swipe Attack
+          - Strong melee attack. A common strategy to deal with the mechanic is to Resonance it to heal some health back. Requires precise timing and manual input.
 .
-_ _
+
 > **More advanced scenarios:**
 What if I use revolution but I manually activate basics most of the time? What benefit will full manual provide at that point?
 This is a really good point and at this stage, there’s very minute things that full manual can offer to aid you in combat. Most of the examples below will relate to auto attacks. Revolution inherently does not interact smoothly with auto attacks unlike full manual.


### PR DESCRIPTION
still early on in this, so very much a work in progress. not ready to upload!! trying to do a full rewrite to be in line with the style guide, and also offer methods of switching from revo to full manual (i.e. can enable queueing with revo to still have revo as a backup but start getting into manually inputting abilities without fighting revo too hard, or ripping off the bandaid and just going head first into full manual) as well as offering safe places to practice full manual like dummies, gwd2, magister, etc. should probably also refer people to #interface-guide as that has the keybind guide in it