### PR TITLE
Worked on #Unlockable-abilities (#Abilities)

### DIFF
--- a/upgrading-info/abilities.txt
+++ b/upgrading-info/abilities.txt
@@ -1,54 +1,55 @@
 > **__Unlockable Abilities__**
 These abilities are classified by either being unlocked as a quest reward, purchased from a shop (Shattered Worlds), or by using an ability codex.
 
-.
 > **__Abilities unlocked by quests__**
 .tag:quests
 ⬥ <:Sunshine:583430011948630016> <:ds:535541258924326912> **Sunshine/Death Swiftness** (Requires level 81 in either Magic or Ranged)
-    • Unlocked upon completion of **The World Wakes** 
-    • These are ultimate abilities with a 7x7 range with the following effects for their corresponding styles:
-        - Increase your damage by 50% (bleeds excluded).
-        - a DoT of 10%-20% that hits every 2 seconds when your primary target of casting is inside the ultimate's radius.
-        - Lasts 30 seconds.
-    • **Note:** Can be used in conjuction with a Planted Feet perk. This makes them last 37 seconds as opposed to 30 seconds, and it removes their DoT effect.
-    • Priority: `High`
+       • Unlocked upon completion of **The World Wakes** 
+       • These are ultimate abilities with a 7x7 range with the following effects for their corresponding styles:
+           - Increase your damage by 50% (bleeds excluded).
+           - a DoT of 10%-20% ability damage that hits every 2 seconds when your primary target of casting is inside the ultimate's radius.
+           - Lasts 30 seconds.
+       • **Note:** Can be used in conjuction with a Planted Feet perk. This makes them last 37 seconds as opposed to 30 seconds, and it removes their DoT effect.
+       • Priority: `High`
 
 .
-⬥ <:bloodtendrils:535532854327640064> <:shadowtend:642713547142332416> <:Smoke_Tendrils:536257336130404372> <:IceAsylum:553050196817215491> **Tendrils Abilities and Ice Asylum**
-⬥ Tendrils Abilities (Requires level 75 in either Attack, Ranged, or Magic)
-    • Unlocked upon reading the Codex Ultimatus after completing **The Dig Site** quest.
-    • Tendrils abilities are thresholds that cause self-damage in order to deal damage to the target.
+
+⬥ <:bloodtendrils:535532854327640064> <:shadowtend:642713547142332416> <:Smoke_Tendrils:536257336130404372> <:IceAsylum:553050196817215491> **Tendrils Abilities and Ice Asylum** (Requires level 75 in either Attack, Ranged, Magic or 91 Constitution)
+       • Unlocked upon reading the Codex Ultimatus after completing **The Dig Site** quest.
+           - All abilities are unlocked on reading the codex but require a specific requirement to use.
+       • Tendrils abilities are thresholds that cause **self-damage** in order to deal damage to the target.
        
-⬥ <:bloodtendrils:535532854327640064> Blood Tendrils
-    • Melee tendrils ability.
-    • Bleed that hits 5 times total. First hit is 36-180% ability damage, followed by 4 hits of 18%-90% ability damage.
-        - Self-damage 27% of the damage dealt after the initial hit.
-    • **Note:** Works with Masterwork Spear of Annihilation for a total of 7 hits.
-    • Priority: `High`
+⬥ <:bloodtendrils:535532854327640064> Blood Tendrils (Requires 75 Attack)
+       • Melee tendrils ability.
+       • Bleed that hits 5 times total. First hit is 36-180% ability damage, followed by 4 hits of 18%-90% ability damage.
+           - Self-damage 27% of the damage dealt after the initial hit.
+       • **Note:** Works with Masterwork Spear of Annihilation for a total of 7 hits.
+       • Priority: `High`
        
-⬥ <:shadowtend:642713547142332416> Shadow Tendrils
-    • Ranged tendrils ability.
-    • A single large hit ranging from 66%-500% ability damage.
-        - Self-damage is half of the total damage dealt.
-    • **Note:** Shadow tendrils damage is increased by modifiers such as Death's Swiftness without adding more self-damage taken.
-    • Priority: `High`
+⬥ <:shadowtend:642713547142332416> Shadow Tendrils (Requires 75 Ranged)
+       • Ranged tendrils ability.
+       • A single large hit ranging from 66%-500% ability damage.
+           - Self-damage is half of the total damage dealt.
+       • **Note:** Shadow tendrils damage is increased by modifiers such as Death's Swiftness without adding more self-damage taken.
+       • Priority: `High`
           
-⬥ <:Smoke_Tendrils:536257336130404372> Smoke Tendrils
-    • Magic tendrils ability
-    • A channeled ability that does 115%-575% ability damage total over 4 hits in 6 seconds.
-        - Self-damage is 35%-175% ability damage over 3 hits in 6 seconds.
-    • **Note:** Smoke Tendrils is comparatively weak due to how long it takes to get all of the damage out.
-    • Priority: `Low`
+⬥ <:Smoke_Tendrils:536257336130404372> Smoke Tendrils (Requires 75 Magic)
+       • Magic tendrils ability.
+       • A channeled ability that does 115%-575% ability damage total over 4 hits in 6 seconds.
+           - Self-damage is 35%-175% ability damage over 3 hits in 6 seconds.
+       • **Note:** Smoke Tendrils is comparatively weak due to how long it takes to get all of the damage out.
+       • Priority: `Low`
 
 .
+
 ⬥ <:IceAsylum:553050196817215491> Ice Asylum (Requires level 91 Constitution)
-    • Constitution ability
-    • An area-of-effect healing ultimate ability.
-    • Heals anyone near the crystal for 1%-7% of their maximum Life Points every 6 ticks (3.6 seconds).
-    • Heals a total of 300% of the user's max hp and runs out when all hp has been healed or after 37 ticks (22.2 seconds).
-    • **Note:** This ability is functionally identical to the Enhanced Excalibur <:EnhancedExcalibur:513200949016264727> but costs 100% adrenaline. 
-    • Should never be used.
-    • Priority: `Low`
+       • Constitution ability
+       • Heals anyone within 8 tiles the crystal for 1%-7% of their maximum Life Points every 6 ticks (3.6 seconds).
+           - Heals a total of 300% of the user's max hp and runs out when all hp has been healed or after 37 ticks (22.2 seconds).
+           - Shares cooldown with Rejuvenate, Guthix's Blessing and Enhanced Excalibur.
+       • **Note:** This ability is functionally identical to the Enhanced Excalibur <:EnhancedExcalibur:513200949016264727> but costs 100% adrenaline. 
+       • Should never be used.
+       • Priority: `Low`
 
 .
 > **__Buyable abilities__**
@@ -57,207 +58,224 @@ __**Raids**__
 These abilities are unlocked using a Mazcab Ability Codex <:coins:698816156961603654> $data_pvme:Unlocks!B1$
 
 ⬥ <:corruptblast:513190159194259467> Corruption Blast (Requires level 70 Magic)
-    • A magic bleed ability that does 33%-100% ability damage every 2 ticks (1.2 seconds) for 10 ticks (6 seconds).
-    • Each bleed hit is 20% weaker than the last, it is also AoE, it can chain to other mobs without giving you aggro.
-    • **Note:** Bleeds are discouraged in group pvm because they override each other and cancel out the current bleed.
-    • Priority: `High`
+       • A magic bleed ability that does 33%-100% ability damage every 2 ticks (1.2 seconds) for 10 ticks (6 seconds).
+       • Each bleed hit is 20% weaker than the last, it is also AoE, it can chain to other mobs without giving you aggro.
+       • **Note:** Bleeds are discouraged in group pvm because they override each other and cancel out the current bleed.
+       • Priority: `High`
 
 ⬥ <:corruptshot:535541306294796299> Corruption Shot (Requires level 70 Ranged)
-    • A ranged bleed ability that does 33%-100% ability damage every 2 ticks (1.2 seconds) for 10 ticks (6 seconds).
-    • Each bleed hit is 20% weaker than the last, it is also AoE, it can chain to other mobs without having them turn aggressive towards you.
-    • **Note:** Bleeds are discouraged in group pvm because they override each other and cancel out the current bleed.
-    • Priority: `High`
+       • A ranged bleed ability that does 33%-100% ability damage every 2 ticks (1.2 seconds) for 10 ticks (6 seconds).
+       • Each bleed hit is 20% weaker than the last, it is also AoE, it can chain to other mobs without having them turn aggressive towards you.
+       • **Note:** Bleeds are discouraged in group pvm because they override each other and cancel out the current bleed.
+       • Priority: `High`
 
 ⬥ <:onsl:513190159085207555> **Onslaught** (Requires level 90 Constitution)
-    • A channeled ability that deals 50-150% damage on the first hit, and each subsequent hit dealing an additional 11%-33% ability damage per hit.
-    • This ability drains your adrenaline (25% per hit) until it runs out. 
-    • Once adrenaline is depleted, Onslaught will start draining your lifepoints. It will deal 25% of the damage dealt as recoil until 10 total hits. 
-        - After the 10th hit, each subsequent hit adds an additional 1000 hp recoil. 
-    • Priority: `Medium`
+      • A channeled ability that deals 50-150% damage on the first hit, and each subsequent hit dealing an additional 11%-33% ability damage per hit.
+      • This ability drains your adrenaline (25% per hit) until it runs out. 
+      • Once adrenaline is depleted, Onslaught will start draining your lifepoints. It will deal 25% of the damage dealt as recoil until 10 total hits. 
+          - After the 10th hit, each subsequent hit adds an additional 1000 hp recoil. 
+      • Priority: `Medium`
 
 .
+
 ⬥ <:Shard:583429757975396366> <:Shatter:583429757761224715> **Storm Shards/Shatter** (Requires level 70 Constitution)
-Both abilities are unlocked together.
+      •**Note:** Both abilities are unlocked together.
+
 ⬥ <:Shard:583429757975396366> Storm Shards
-    • Apply a Storm Shard stack to an enemy when used, dealing no damage. A total of 10 Storm Shard stacks can be applied to an enemy.
-    • Each stack stores 75%-95% ability damage which can be cashed out in one big hit by using the Shatter ability.
-    • **Note:** Shards themselves are unaffected by things such as Berserk, Sunshine, etc.
-    • Generally used on timegated parts of bosses or if you need to do a lot of burst at once with shatter.
-    • Priority: `High for Vorago, low otherwise`
+      • Apply a Storm Shard stack to an enemy when used, dealing no damage. A total of 10 Storm Shard stacks can be applied to an enemy.
+      • Each stack stores 75%-95% ability damage which can be cashed out in one big hit by using the Shatter ability.
+      • **Note:** Shards themselves are unaffected by things such as Berserk, Sunshine, etc.
+      • Generally used on timegated parts of bosses or if you need to do a lot of burst at once with shatter.
+      • Priority: `High for Vorago, low otherwise`
 
 ⬥ <:Shatter:583429757761224715> Shatter (Requires level 70 Constitution)
-    • Releases all the stored Storm Shard stacks at once dealing damage equivalent to the stored shards, for a cap of 30,000 damage.
-    • This hit is affected by damage modifiers like Berserk, Sunshine, etc.
-    • Priority: `High for Vorago, low otherwise`
+      • Releases all the stored Storm Shard stacks at once dealing damage equivalent to the stored shards, for a cap of 30,000 damage.
+      • This hit is affected by damage modifiers like Berserk, Sunshine, etc.
+      • Priority: `High for Vorago, low otherwise`
 
 .
+
 **__Raksha__**
 ⬥ <:grico:787904334812807238> **Greater Ricochet** (Requires level 45 Ranged)
-    • Unlocked using a Greater Ricochet ability codex.
-    • Aoe ability that does 20%-100% ability damage on the initial hit.
-        - Can damage up to 2 additional targets (a total of 7 hits with Caroming 4).
-        - The primary target will be hit for an additional 10%-50% ability damage for each ricochet shot that cannot find an additional target.
-    • **Note:** Works with the Caroming perk.
-    • Priority: `High`
+      • Unlocked using a Greater Ricochet ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B14$
+      • Aoe ability that does 20%-100% ability damage on the initial hit.
+          - Can damage up to 2 additional targets (a total of 7 hits with Caroming 4).
+          - The primary target will be hit for an additional 10%-50% ability damage for each ricochet shot that cannot find an additional target.
+      • **Note:** Works with the Caroming perk.
+      • Priority: `High`
 
 
 ⬥ <:gchain:787904334495088672> **Greater Chain** (Requires level 45 Magic)
-    • Unlocked using a Greater Chain ability codex.
-    • Aoe ability that does 20%-100% ability damage.
-        - Damage up to 2 additional targets.
-    • The next ability on the primary target is also cast on the additional targets with a 50% damage reduction.
-        - 6 second duration.
-    • **Note:** Works with the Caroming perk.
-    • Priority: `Medium`
-
+      • Unlocked using a Greater Chain ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B15$
+      • Aoe ability that does 20%-100% ability damage.
+          - Damage up to 2 additional targets.
+      • The next ability on the primary target is also cast on the additional targets with a 50% damage reduction.
+          - 6 second duration.
+      • **Note:** Works with the Caroming perk.
+      • Priority: `Medium`
 
 ⬥ <:divert:787904334377648130> **Divert** (Requires level 48 Defense)
-    • Unlocked using a Divert ability codex.
-    • The next Melee, Magic, or Ranged attack received by the player within 6 seconds will block the hit and grant the player adrenaline.
-        - Generate 0.8% adrenaline for every 100-200 damage blocked, based on the level of shield equipped with diminishing returns at 3,000, 6,000 and 9,000 damage blocked.
-        - Powerful attacks will have their damage blocked, but will not generate adrenaline (i.e. Telos `So Much Power` or `Weak Anima Bomb` special attacks).
-    • **Note:** Shares cooldown with resonance.
-    • Priority: `Medium`
+      • Unlocked using a Divert ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B16$
+      • The next Melee, Magic, or Ranged attack received by the player within 6 seconds will block the hit and grant the player adrenaline.
+          - Generate 0.8% adrenaline for every 100-200 damage blocked, based on the level of shield equipped with diminishing returns at 3,000, 6,000 and 9,000 damage blocked.
+          - Powerful attacks will have their damage blocked, but will not generate adrenaline (i.e. Telos `So Much Power` or `Weak Anima Bomb` special attacks).
+      • **Note:** Shares cooldown with resonance.
+      • Priority: `Medium`
 
 .
+
 **__Telos__**
 ⬥ <:Reprisal:513190159462694912> **Reprisal** (Requires level 85 Constitution)
-    • Unlocked using a Reprisal Ability Codex <:coins:698816156961603654> $data_pvme:Unlocks!B9$
-    • When activated it tracks all damage taken from all sources for up to 6 seconds (can release early by activating it again) with a damage cap of 10,000
-    • **Note:** It releases the damage on whatever you were targetting when you activated it..
-    • Damage is boosted by Zerk auras, Vulnerability, etc.
-    • Generally used when you are going to take a large amount of damage at once, like Vorago's Teamsplit attack.
-    • Priority: `High if you do something like Vorago, Low otherwise`
+      • Unlocked using a Reprisal Ability Codex <:coins:698816156961603654> $data_pvme:Unlocks!B9$
+      • When activated it tracks all damage taken from all sources for up to 6 seconds (can release early by activating it again) with a damage cap of 10,000
+      • **Note:** It releases the damage on whatever you were targetting when you activated it.
+          - Damage on activation is boosted by Zerk auras, Vulnerability, etc.
+          - Damage stored is based on damage taken. Defensives and the Trimmed Masterwork passive will reduce this.
+      • Generally used when you are going to take a large amount of damage at once, like Vorago's Teamsplit attack.
+      • Priority: `High if you do something like Vorago, Low otherwise`
 
 .
+
 **__Elite Dungeon 2__**
 ⬥ <:gbarge:535532879250456578> **Greater Barge** (Requires level 30 Attack)
-    • Unlocked using a Greater Barge ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B10$
-    • Works like normal barge, except each tick (0.6 seconds) the player is not damaging an enemy, barge gains +10% ability damage capping at 10 ticks. 
-    • If it has been at least 8 ticks (4.8 seconds) since you have last hit a target, using barge will allow you to turn a channeled ability used within the next 6 seconds (10 ticks) into a Damage over Time ability.
-    • Generally used within Zerk combined with Adrenaline potion or Limitless, as well as in a Zaros Godsword special attack.
-    • Priority: `High`
+      • Unlocked using a Greater Barge ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B10$
+      • Works like normal barge, except each tick (0.6 seconds) the player is not damaging an enemy, barge gains +10% ability damage capping at 10 ticks. 
+      • If it has been at least 8 ticks (4.8 seconds) since you have last hit a target, using barge will allow you to turn a channeled ability used within the next 6 seconds (10 ticks) into a Damage over Time ability.
+      • Generally used within Zerk combined with Adrenaline potion or Limitless, as well as in a Zaros Godsword special attack.
+      • Priority: `High`
 
 ⬥ <:gflurry:535532879283879977> **Greater Flurry** (Requires level 37 Attack)
-    • Unlocked using a Greater Flurry ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B11$
-    • When used against a single target it deals 94-157% damage per hit and reduces Berserk cooldown by 2 tick (1.2 seconds) per successful hit up to a max of 8 ticks (4.8 seconds) reduction.
-    • **Note:** When used as an AoE does the same damage as normal flurry, but still reduces Berserk cooldown.
-    • **Note:** When bled the first hit does its AoE version of damage, then normal single target damage for the remaining hits.
-        - Generally canceled after 2 hits (cancelled on GCD) or 3 hits, depending on the rotation used.
-    • Priority: `Medium`
+      • Unlocked using a Greater Flurry ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B11$
+      • When used against a single target it deals 94-157% damage per hit and reduces Berserk cooldown by 2 tick (1.2 seconds) per successful hit up to a max of 8 ticks (4.8 seconds) reduction.
+      • **Note:** When used as an AoE does the same damage as normal flurry, but still reduces Berserk cooldown.
+      • **Note:** When bled the first hit does its AoE version of damage, then normal single target damage for the remaining hits.
+          - Generally canceled after 2 hits (cancelled on GCD) or 3 hits, depending on the rotation used.
+      • Priority: `Medium`
 
 ⬥ <:gfury:535532879334080527> **Greater Fury** (Requires level 24 Strength)
-    • Unlocked using a Greater Fury ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B12$
-    • Turns fury into a non-channeled 157% ability, as well as giving it the ability to guarantee your next hit is a critical hit if fury had been a critical hit.
-    • **Note:** Can be worse than normal fury, but marginally assuming no grim. With grim it is usually better.
-    • Priority: `Medium`
+      • Unlocked using a Greater Fury ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B12$
+      • Turns fury into a non-channeled 157% ability, as well as giving it the ability to guarantee your next hit is a critical hit if fury had been a critical hit.
+      • **Note:** Can be worse than normal fury, but marginally assuming no grim. With grim it is usually better.
+      • Priority: `Medium`
 
 .
+
 **__Anachronia__**
 ⬥ <:surgecodex:602561894414417944> **Double Surge** (Requires level 30 Magic)
-    • Unlocked using a Double Surge codex <:coins:698816156961603654> $data_pvme:Unlocks!B7$
-    • Gives Surge 2 uses per cooldown cycle, these can both grant adrenaline if both are used off global cooldown
-    • **Note:** The cooldown is based on the first surge/escape
-    • **Note:** Can change the cooldown between charges at the Anachronia Lectern
-    • Generally just used for mobility, overall a QOL unlocked
-    • Priority: `Medium`
+      • Unlocked using a Double Surge codex <:coins:698816156961603654> $data_pvme:Unlocks!B7$
+      • Gives Surge 2 uses per cooldown cycle, these can both grant adrenaline if both are used off global cooldown
+      • **Note:** The cooldown is based on the first surge/escape
+      • **Note:** Can change the cooldown between charges at the Anachronia Lectern
+      • Generally just used for mobility, overall a QOL unlocked
+      • Priority: `Medium`
 
 ⬥ <:escapecodex:602561894443778115> **Double Escape** (Requires level 30 Ranged)
-    • Unlocked using a Double Escape codex <:coins:698816156961603654> $data_pvme:Unlocks!B8$
-    • Gives Escape 2 uses per cooldown cycle, these can both grant adrenaline if both are used off global cooldown
-    • **Note:** The cooldown is based on the first surge/escape
-    • **Note:** Can change the cooldown between charges at the Anachronia Lectern
-    • Generally just used for mobility, overall a QOL unlocked
-    • Priority: `Medium`
+      • Unlocked using a Double Escape codex <:coins:698816156961603654> $data_pvme:Unlocks!B8$
+      • Gives Escape 2 uses per cooldown cycle, these can both grant adrenaline if both are used off global cooldown
+      • **Note:** The cooldown is based on the first surge/escape
+      • **Note:** Can change the cooldown between charges at the Anachronia Lectern
+      • Generally just used for mobility, overall a QOL unlocked
+      • Priority: `Medium`
 
 .
+
 **__Miscellaneous Buyable Abilities__**
 ⬥ <:limitless:641339233638023179> **Limitless** (Requires level 10 Constitution)
-    • Unlocked using a Limitless ability codex <:coins:698816156961603654> $data_pvme:Unlocks!E1$
-        - Made by combining 2000 vital sparks.
-    • An ability that allows the usage of thresholds under 50% adrenaline for 6 seconds.
-    • **Note:** Only activates when below 60% adrenaline.
-    • Generally used when your Adrenaline potion is on cooldown or if you need to squeeze in extra thresholds in a short timeframe.
-    • Priority: `High`
+      • Unlocked using a Limitless ability codex <:coins:698816156961603654> $data_pvme:Unlocks!E1$
+          - Made by combining 2000 vital sparks.
+      • An ability that allows the usage of thresholds under 50% adrenaline for 6 seconds.
+      • **Note:** Cannot be used if above 60% adrenaline.
+      • **Note:** Thresholds still cost 15% adrenaline.
+      • Generally used when your Adrenaline potion is on cooldown or if you need to squeeze in extra thresholds in a short timeframe.
+      • Priority: `High`
 
 ⬥ <:ingen:641339234111848463> **Ingenuity of the Humans** (Requires level 10 Constitution)
-    • Unlocked using an Ingenuity of the Humans ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B6$
-    • An ability that guarantees your next spell or ability within 10 ticks (6 seconds) hits.
-    • Priority: `High`
+      • Unlocked using an Ingenuity of the Humans ability codex <:coins:698816156961603654> $data_pvme:Unlocks!B6$
+      • An ability that guarantees your next spell or ability within 10 ticks (6 seconds) hits.
+      • Priority: `High`
 
 <:undeadslayerperk:689502804720615441> <:dragonslayerperk:689502927731163170> <:demonslayerperk:689502842653900818> **__X__ Slayers** (Requires level 10 Constitution)
 ⬥ Unlocked using a __X__ Slayer ability codex
-    • <:undeadslayerperk:689502804720615441> Undead Slayer <:coins:698816156961603654> $data_pvme:Unlocks!B3$
-    • <:dragonslayerperk:689502927731163170> Dragon Slayer <:coins:698816156961603654> $data_pvme:Unlocks!B5$
-    • <:demonslayerperk:689502842653900818> Demon Slayer <:coins:698816156961603654> $data_pvme:Unlocks!B4$
-    • When used you will deal 15% more damage against X creature of the same type for 17 ticks (10 seconds).
-    • Generally used when you are going to use strong abilities against said creature.
-    • Priority: `High if you can use it, Low otherwise`
+      • <:undeadslayerperk:689502804720615441> Undead Slayer <:coins:698816156961603654> $data_pvme:Unlocks!B3$
+      • <:dragonslayerperk:689502927731163170> Dragon Slayer <:coins:698816156961603654> $data_pvme:Unlocks!B5$
+      • <:demonslayerperk:689502842653900818> Demon Slayer <:coins:698816156961603654> $data_pvme:Unlocks!B4$
+      • When used you will deal 15% more damage against X creature of the same type for 17 ticks (10 seconds).
+      • Generally used when you are going to use strong abilities against said creature.
+      • Priority: `High if you can use it, Low otherwise`
 
 .
+
 > **__Abilities unlocked by activities__**
 .tag:activity
+
 **__God Wars Dungeon / Anima Islands__**
 ⬥ <:devo:513190158728953857> **Devotion** (Requires level 1 Defense)
-    • Chance to unlock after killing Kree'arra, General Graardor, or their followers in their respective encampments.
-    • Alternatively can be unlocked as a reward from Anima Islands.
-    • When activated, all damage dealt whilst using a protection prayer or deflect curse of the same style is reduced to 1 for 16 ticks (9.6 seconds).
-        - Effect extends by 5 seconds per target killed whilst active, capping at 20 seconds.
-    • Priority: `High`
+      • Chance to unlock after killing Kree'arra, General Graardor, or their followers in their respective encampments.
+      • Alternatively can be unlocked as a reward from Anima Islands.
+      • When activated, all damage dealt whilst using a protection prayer or deflect curse of the same style is reduced to 1 for 16 ticks (9.6 seconds).
+          - Effect extends by 5 seconds per target killed whilst active, capping at 20 seconds.
+      • Priority: `High`
 
 ⬥ <:Sacrifice:513201065907322880> **Sacrifice** (Requires level 10 Constitution)
-    • Chance to unlock after killing Kree'arra, General Graardor, or their followers in their respective encampments.
-    • Alternatively can be unlocked as a reward from Anima Islands.
-    • Basic ability that does 20-100% ability damage.
-        - Heals 25% of damage done, 100% if it killed target.
-    • Priority: `Low`
+      • Chance to unlock after killing Kree'arra, General Graardor, or their followers in their respective encampments.
+      • Alternatively can be unlocked as a reward from Anima Islands.
+      • Basic ability that does 20-100% ability damage.
+          - Heals 25% of damage done, 100% if it killed the target.
+      • Priority: `Low`
 
 ⬥ <:Transfigure:553050196523876354> **Transfigure** (Requires level 10 Constitution)
-    • Incapacitate yourself for 10 ticks (6 seconds).
-    • Afterwards heal 250% of any damage taken, to a maximum of 75% of your Life Points.
-    • Become immune to binds and stuns for 15 seconds.
-      
-⬥ <:Tuskas:513201065513058306> **Tuska's Wrath** (Requires level 50 Constitution)
-    • Unlocked as a reward from Anima Islands
-    • When on slayer task, you deal (100 x Slayer level) damage to target assuming it is the monster you are assigned. This gives it a 120 second cooldown.
-    • Caps at 15,000 damage.
-    • **Note:** This also works on some bosses like Magister while on a Soul Devourer task.
-        - If not on slayer task, this ability deals 30%-110% ability damage with a 15 second cooldown.
-    • Generally only used as a filler ability if you mess up your rotation, should not be a regular part of your rotation.
-    • Priority: `High if doing a lot of slayer, low otherwise`
+      • Incapacitate yourself for 10 ticks (6 seconds).
+          - You can still eat food, drink potions and switch prayers during this period.
+      • Afterwards heal 250% of any damage taken, to a maximum of 75% of your Life Points.
+      • Become immune to binds and stuns for 15 seconds.
+      • Priority: `Low`
 
 .
+
+⬥ <:Tuskas:513201065513058306> **Tuska's Wrath** (Requires level 50 Constitution)
+      • Unlocked as a reward from Anima Islands
+      • When on slayer task, you deal (100 x Slayer level) damage to target assuming it is the monster you are assigned. This gives it a 120 second cooldown.
+      • Caps at 15,000 damage.
+      • **Note:** This also works on some bosses like Magister while on a Soul Devourer task.
+          - If not on slayer task, this ability deals 30%-110% ability damage with a 15 second cooldown.
+      • Generally only used as a filler ability if you mess up your rotation, should not be a regular part of your rotation.
+      • Priority: `High if doing a lot of slayer, low otherwise`
+
+.
+
 **__Shattered Worlds__**
 ⬥ <:bd:535532854281764884> **Bladed Dive** (Requires level 65 Attack)
-    • A great mobility ability, has a 10 tile range from your current position at any angle.
-    • Generally used in conjunction with surge/escape, sometimes on the same tick, for greater mobility.
-    • Functions as a 3x3 AoE ability when used off global cooldown.
-    • **Note:** goes from 3x3 to 5x5 when stacked with scythe and laceration boots.
-        - Cooldown instantly resets if the target dies within 10 ticks (6 seconds) of using Bladed Dive.
-    • Priority: `High`
+      • A great mobility ability, has a 10 tile range from your current position at any angle.
+      • Generally used in conjunction with surge/escape, sometimes on the same tick, for greater mobility.
+      • Functions as a 3x3 AoE ability when used off global cooldown.
+      • **Note:** goes from 3x3 to 5x5 when stacked with scythe and laceration boots.
+      • **Note:** Cooldown instantly resets if the target dies within 10 ticks (6 seconds) of using Bladed Dive.
+      • Priority: `High`
 
-⬥ <:mds:535541259033378827> <:stw:535541259109138463> **Greater Dazing Shot/Salt the Wound**
-Both abilities are unlocked together.
+⬥ <:mds:535541259033378827> <:stw:535541259109138463> **Greater Dazing Shot & Salt the Wound** (Requires level 8 Ranged for Greater Dazing Shot, level 60 Ranged for Salt the Wound)
+**Note:** Unlocking Greater Dazing Shot also unlocks Salt the Wound.
+
 ⬥ <:mds:535541259033378827> Greater Dazing Shot (Requires level 8 Ranged)
-    • Gives Dazing Shot a puncture stack each time it is used, with a maximum of 10 puncture stacks on a target.
-    • Puncture stacks last 9 seconds and hit 4 times (every 3 ticks or 1.8 seconds), dealing 8%-10% ability damage per stack over its duration.
-    • Note: Salt the Wound and Greater Dazing Shot both reset the stack duration (9 seconds) even if they splash, only Greater Dazing Shot will increase puncture count though.
-    • Note: Puncture bleed does not count for:
-        - Aftershock building
-        - Soulsplit
-        - Araxxor web shield reflect
-        - Personal damage multipliers such as scrimshaws
-        - Combat experience
-        - Challenge gems
-        - Nex's blood phase
-    • Priority: `Medium`
+      • Gives Dazing Shot a puncture stack each time it is used, with a maximum of 10 puncture stacks on a target.
+      • Puncture stacks last 9 seconds and hit 4 times (every 3 ticks or 1.8 seconds), dealing 8%-10% ability damage per stack over its duration.
+      • Note: Salt the Wound and Greater Dazing Shot both reset the stack duration (9 seconds) even if they splash, only Greater Dazing Shot will increase puncture count though.
+      • Note: Puncture bleed does not count for:
+          - Aftershock building
+          - Soulsplit
+          - Araxxor web shield reflect
+          - Personal damage multipliers such as scrimshaws
+          - Combat experience
+          - Challenge gems
+          - Nex's blood phase
+       • Priority: `Medium`
            
 ⬥ <:stw:535541259109138463> Salt the Wound (Requires level 60 Ranged)
-    • A threshold that deals 37.6%-188% ability damage at 0 puncture stacks, going up to 73.6-368% with 10 puncture stacks.
-    • Generally never used.
-    • Priority: `Low`
-       
+      • A threshold that deals 37.6%-188% ability damage at 0 puncture stacks, going up to 73.6-368% with 10 puncture stacks.
+      • Generally never used since it required 8+ stacks to be viable.
+      • Priority: `Low`
+
 .
+
 > **__Table of Contents__**
 ⬥ **Quest Unlocks** - $linkmsg_quests$
 ⬥ **Buyable abilities** - $linkmsg_buy$


### PR DESCRIPTION
Went through confirming that bulletpoints were logical.
Left Notes in where emphasis was important.

Adjusted some of the structure of Tendril abilities
Clarified that Tendrils have unlock requirements and individual requirements to use
Put specific requirements after those abilities.
More detail on Ice Alylum (Range, shared cooldowns)

Added mention to Reprisal that damage stored is altered by defensives/TMW

Added a note to Limitless that thresholds still cost adrenaline.

Additional notes to Transfigure
Added priority to Transfigure (AKA Low)

Moved Bladed Dive cooldown to a Note rather than a subsubpoint.

Standardised gaps between paragraphs

Greater Dazing and Salt the Wound adjusted.