### PR TITLE
Dpm-Advice-FAQ Minor Changes

### DIFF
--- a/dpm-advice/dpm-advice-faq.txt
+++ b/dpm-advice/dpm-advice-faq.txt
@@ -8,14 +8,14 @@ The following list notes some of the common mistakes made by players in PvM. It 
 .tag:ccsa
 .
 **__Channeled abilities__**
-⬥ Concentrated Blast <:conc:535533833106489365>:2hit (3t/1.8s)
-⬥ Snipe <:snipe:535541258425204770>:(4t/2.4s)
-⬥ Fury <:fury:535532879510372352>:2hit (3t/1.8s)
-⬥ Asphyxiate <:asphyx:535533833072672778>:4hit (7t/4.2s)
-⬥ Rapid fire <:rapid:535541270521708566>:8 hit (8t/5.6s)
-⬥ Assault <:assault:535532853979512842>:4hit (7t/4.2s)
-⬥ Destroy <:destroy:535532879330148352>:4hit (7t/4.2s)
-⬥ Greater Flurry <:gflurry:535532879283879977>:2 or 3 hit(3t/1.8s or 5t/3.0s)
+⬥ Concentrated Blast <:conc:535533833106489365>: 2hit (3t/1.8s)
+⬥ Snipe <:snipe:535541258425204770>: (4t/2.4s)
+⬥ Fury <:fury:535532879510372352>: 2hit (3t/1.8s)
+⬥ Asphyxiate <:asphyx:535533833072672778>: 4hit (7t/4.2s)
+⬥ Rapid fire <:rapid:535541270521708566>: 8 hit (8t/5.6s)
+⬥ Assault <:assault:535532853979512842>: 4hit (7t/4.2s)
+⬥ Destroy <:destroy:535532879330148352>: 4hit (7t/4.2s)
+⬥ Greater Flurry <:gflurry:535532879283879977>: 2 or 3 hit(3t/1.8s or 5t/3.0s)
 
 *Note: The listed cancel timings are standard, depending on overall rotation the cancel time you use may differ*
 .
@@ -122,7 +122,7 @@ Practice, try and think 2 abilities ahead and plan out your rotation.
 .tag:changing
 .
 **__Why it’s important:__** 
-Changing from DW to 2H mid-Conc <:conc:535533833106489365>  will lose you the crit bonus from the ability. This requires precise timing to make sure you’re still getting 2 hits from your conc blast. Moreover, this resets your auto cooldown which is bad for 4TAA.
+Changing your weapon mid-Conc <:conc:535533833106489365> will cancel it. Thus this requires precise timing to make sure you’re still getting 2 hits from your conc blast. Further, changing your main-hand mid-Conc <:conc:535533833106489365> will lose you the crit bonus from the ability. 
 
 **__How to fix:__** 
 Practice the timing.


### PR DESCRIPTION
Changes made:
• Added some missing spaces
• Changed: Changing from DW to 2H mid-Conc <:conc:535533833106489365>  will lose you the crit bonus from the ability. This requires precise timing to make sure you’re still getting 2 hits from your conc blast. Moreover, this resets your auto cooldown which is bad for 4TAA.
  To: Changing your weapon mid-Conc <:conc:535533833106489365> will cancel it. Thus this requires precise timing to make sure you’re still getting 2 hits from your conc blast. Further, changing your main-hand mid-Conc <:conc:535533833106489365> will lose you the crit bonus from the ability.