### PR TITLE
Update overview-of-slayer.txt

### DIFF
--- a/slayer/overview-of-slayer.txt
+++ b/slayer/overview-of-slayer.txt
@@ -91,7 +91,7 @@ Some base action bars are shown below
 ⬥ **Ring of Vigour** <:vigour:615613235512737792> - Refunds 10% adrenaline on use of an ultimate ability.
 
 .
-⬥ **Kethsi Ring** - Provides a 4% damage buff against dragons, 8% inside Kuradal's dungeon.
+⬥ **Kethsi Ring** - Provides a 4% damage buff against metal dragons, 8% inside Kuradal's dungeon.
 
 .
 ⬥ **Darklight** - Upgraded after the Dimension of Disaster quest, BiS mainhand weapon for killing demons.


### PR DESCRIPTION
made it clear that the Kethsi Ring only gives its damage buff against metal dragons.