### PR TITLE
Update perk-info.txt

### DIFF
--- a/getting-started/perk-info.txt
+++ b/getting-started/perk-info.txt
@@ -1,6 +1,6 @@
 > __**Introduction**__
 .tag:intro
-This channel explains the perk choices and placements, for the combos and positions of perks on gear check out <#553632787639435284>.
+This channel explains perk choices and placements. For the combos and positions of perks on gear, check out <#553632787639435284>.
 
 .
 > **__Entry Level Weapon Perks__**
@@ -9,7 +9,7 @@ This channel explains the perk choices and placements, for the combos and positi
 ⬥ Approximately a 7.1% DPM (damage per minute) increase over not having any weapon perks at all.
 ⬥ Super cheap to obtain once you've unlocked Ancient Gizmos <:ancientarmourgizmo:697405383769194516> <:ancientweapongizmo:697405383752548382>. 
 ⬥ Don't have to worry about maintaining Aftershock <:as4:712074245202772009> stacks when using switches such as a shield or Guthix Staff spec <:gstaff:513203008608141314> <:spec:537340400273195028>.
-⬥ Precise 6 <:p6:712073088769982475> on mainhand to maximise damage while using a Flank/Defender/Shield <:flank4:712073088296157185>/<:kalphiterepriser:643846849362657280>/<:vengeful_kiteshield:536258767344500746> switch.
+⬥ Precise 6 <:p6:712073088769982475> on mainhand to maximise damage while using a Flanking/Defender/Shield <:flank4:712073088296157185>/<:kalphiterepriser:643846849362657280>/<:vengeful_kiteshield:536258767344500746> switch.
 
 .
 **__Flanking 4__** <:flank4:712073088296157185>
@@ -17,26 +17,26 @@ This channel explains the perk choices and placements, for the combos and positi
 ⬥ Multiplies the damage of Forceful Backhand <:fbackhand:535532879346794516>, Deep Impact <:deep:535533833139912724> and Tight Bindings <:tight:535541275957657600> by 1.6x when the target is not facing you.
 ⬥ Removes the stun effect from these abilities if the target is not facing you.
 ⬥ Still quite cheap and common for the benefit it gives.
-⬥ For more information on Flanking Perk <:flank4:712073088296157185> Angle see <#689212192398114875>.
+⬥ For more information on the Flanking Perk <:flank4:712073088296157185> Angle see <#689212192398114875>.
 
 .
 **__Planted Feet__** <:pf:689501925770919981>
 ⬥ Increases the duration of Sunshine <:Sunshine:583430011948630016> and Death's Swiftness <:ds:535541258924326912> from 30s (50 ticks) to 37.8s (63 ticks).
-⬥ Usually comboed with Aftershock 1 <:as1:689502339891331093> on mainhand to preserve stacks.
+⬥ Usually combo-ed with Aftershock 1 <:as1:689502339891331093> on mainhand to preserve stacks.
 
 .
 > **__Advanced Weapon Perks__**
 .tag:weaponadvanced
 **__Precise 6 Aftershock 1 + Aftershock 4 Equilibrium 2__** <:p6:712073088769982475> <:as1:689502339891331093> + <:as4:712074245202772009> <:eq2:689502258424971564>
 ⬥ Approximately 9.6% DPM boost over not having any weapon perks at all.
-⬥ Precise 6 <:p6:712073088769982475> on mainhand boosts all Flank/Defender/Shield <:flank4:712073088296157185>/<:kalphiterepriser:643846849362657280>/<:vengeful_kiteshield:536258767344500746> damage by approximately 6.9%.
+⬥ Precise 6 <:p6:712073088769982475> on mainhand boosts all Flanking/Defender/Shield <:flank4:712073088296157185>/<:kalphiterepriser:643846849362657280>/<:vengeful_kiteshield:536258767344500746> damage by approximately 6.9%.
 ⬥ Aftershock 1 <:as1:689502339891331093> on Mainhand ensures you maintain stacks even when using a switch, and also provides extra damage.
 ⬥ Gives effective Precise 6 <:p6:712073088769982475> + Equilibrium 2 <:eq2:689502258424971564> + Aftershock 4 <:as4:712074245202772009> and is considerably cheaper than attempting to get P6E2 <:p6:712073088769982475> <:eq2:689502258424971564> on one gizmo.
 ⬥ Best perk setup for places where Ruthless <:ruthless3:712244800572883025> is unlikely to be effective.
 
 .
 **__Equilibrium 4 Ruthless 3__** <:eq4:712073088589627505> <:ruthless3:712244800572883025>
-⬥ When comboed with P6AS1 <:p6:712073088769982475> <:as1:689502339891331093> is approximately 8.3% DPM boost over not having any weapon perks at all, before taking Ruthless <:ruthless3:712244800572883025> into account.
+⬥ When combo-ed with P6AS1 <:p6:712073088769982475> <:as1:689502339891331093> ,is approximately an 8.3% DPM boost over not having any weapon perks at all, before taking Ruthless <:ruthless3:712244800572883025> into account.
 ⬥ Cheap to obtain.
 ⬥ Very good at places where Ruthless <:ruthless3:712244800572883025> is effective - e.g. Elite Dungeons, Slayer, Legiones, Chinning AoD etc.
 
@@ -44,13 +44,13 @@ This channel explains the perk choices and placements, for the combos and positi
 **__Lunging 4__** <:lung4:712073737247260753>
 ⬥ Increases max hit of Dismember <:dismember:535532879376023572>, Fragmentation Shot <:frag:535541273755385885> and Combust <:comb:535533833098100745> by +80% on stationary targets.
 ⬥ Reduces the damage of walked Fragmentation Shot <:frag:535541273755385885> and Combust <:comb:535533833098100745> to only 1.5x base damage, rather than the usual 2x.
-⬥ Generally only used with melee as you cannot walk Dismember <:dismember:535532879376023572>, Frag Shot/Combust <:frag:535541273755385885>/<:comb:535533833098100745> are better if walked without lunging.
+⬥ Generally only used with melee as you cannot walk Dismember <:dismember:535532879376023572>; Frag Shot/Combust <:frag:535541273755385885>/<:comb:535533833098100745> are better if walked without lunging.
 
 .
 > **__Entry Level Armour Perks__**
 .tag:armourentry
 **__Biting 3__** <:b3:689502516874051590>
-⬥ Biting 3 <:b3:689502516874051590> gives a 6% (6.6% at level 20) chance of forcing a crit each hit, this come out to an average hit increase of 3.8% (4.18% at level 20).
+⬥ Biting 3 <:b3:689502516874051590> gives a 6% (6.6% at level 20) chance of forcing a crit each hit. This come out to an average hit increase of 3.8% (4.18% at level 20).
 ⬥ Very cheap and easy to obtain.
 ⬥ Approximately a 3.8% DPM boost over not having any form of Biting <:biting4:712073087809617931>.
 
@@ -62,14 +62,14 @@ This channel explains the perk choices and placements, for the combos and positi
 .
 **__Crackling 4__** <:crack4:712073087662686249>
 ⬥ Crackling 4 <:crack4:712073087662686249> deals 200% ability damage every 60 seconds.
-⬥ Can easily be comboed with an auxiliary perk.
+⬥ Can easily be combo-ed with an auxiliary perk.
 
 .
 **__Enhanced Devoted 4__** <:enhdev4:712073087507628035>
 ⬥ Enhanced Devoted 4 <:enhdev4:712073087507628035> has a 18% (19.8% at level 20) chance per hit on you of activating a 3 second version of the Devotion <:devo:513190158728953857> ability.
-⬥ The effectiveness of this depends on the attack speed of a boss, but leads to approximately 18% damage reduction on targets with an attack speed of greater than 4t, or 30.5% on targets with an attack speed of 4t, assuming you always have the correct overhead prayer on.
+⬥ The effectiveness of this depends on the attack speed of a boss, but leads to approximately 18% damage reduction against targets with an attack speed greater than 4t, or 30.5% against targets with an attack speed of 4t, assuming you always have the correct overhead prayer on.
 ⬥ This takes priority over the normal Devoted <:dev4:712073087713280033> perk, however the normal Devoted <:dev4:712073087713280033> perk can activate during the time Enhanced Devotion <:enhdev4:712073087507628035> is active
-⬥ Putting this perk along with Crackling 3 on the legs allows us to use armour switches with different setups at a lower cost since they are generally cheaper.
+⬥ Putting this perk along with Crackling 3 on the legs allows you to use armour switches with different setups at a lower cost since they are generally cheaper.
 
 .
 **__Turtling 4__** <:turt4:712073737377284146>
@@ -80,7 +80,7 @@ This channel explains the perk choices and placements, for the combos and positi
 > **__Advanced Armour Perks__**
 .tag:armouradvanced
 **__Biting 4 X__** <:biting4:712073087809617931>
-⬥ Biting 4 <:biting4:712073087809617931> gives a 8% (8.8% at level 20) chance of forcing a crit each hit, this come out to an average hit increase of 5% (5.5% at level 20)
+⬥ Biting 4 <:biting4:712073087809617931> gives an 8% (8.8% at level 20) chance of forcing a crit each hit. This come out to an average hit increase of 5% (5.5% at level 20).
 ⬥ Approximately a 5% DPM boost over not having Biting <:biting4:712073087809617931>.
 ⬥ Can be comboed with an auxiliary perk but is generally expensive to do so
 
@@ -89,19 +89,19 @@ This channel explains the perk choices and placements, for the combos and positi
 ⬥ Relentless 5 <:relentless5:712244800920748092> gives a 5% (5.5% at level 20) chance to not consume adrenaline when using an ability that requires adrenaline
 ⬥ This includes thresholds, defensives, special attacks and ultimate abilites
 ⬥ Crackling 4 <:crack4:712073087662686249> deals 200% ability damage every 60 seconds
-⬥ As Biting <:biting4:712073087809617931> is expensive, and Relentless <:relentless5:712244800920748092> is a perk useful in all situations, putting them both on the body allows us to use different augmented legs with different perk setups.
+⬥ As Biting <:biting4:712073087809617931> is expensive, and Relentless <:relentless5:712244800920748092> is a perk useful in all situations, putting them both on the body allows you to use different augmented legs with different perk setups.
 
 .
 **__Impatient 4 Devoted 4__** <:imp4:712073088204013640> <:dev4:712073087713280033> 
 ⬥ Due to the lack of Enhanced Devoted <:enhdev4:712073087507628035> it is preferred to combo Impatient 4 <:imp4:712073088204013640> with Devoted 4 <:dev4:712073087713280033> .
 ⬥ Can be comboed with other perks if you opt to use Enhanced Devoted <:enhdev4:712073087507628035> as well.
 ⬥ Devoted 4 <:dev4:712073087713280033> has a 12% (13.2% at level 20) chance per hit on you of activating a 3 second version of the Devotion <:devo:513190158728953857> ability.
-⬥ The effectiveness of this depends on the attack speed of a boss, but leads to approximately 12% damage reduction on targets with an attack speed of greater than 4t, or 21.4% on targets with an attack speed of 4t, assuming you always have the correct overhead prayer on.
+⬥ The effectiveness of this depends on the attack speed of a boss, but leads to approximately 12% damage reduction against targets with an attack speed greater than 4t, or 21.4% against targets with an attack speed of 4t, assuming you always have the correct overhead prayer on.
 
 .
 **__Invigorating 4 X__** <:invig4:712073087859949570>
 ⬥ Invigorating 4 <:invig4:712073087859949570> gives 40% increased adrenaline from auto attacks, the amount depends on the combat style and weapon speed used. For Magic <:Magic:689504724159823906> this is always 0.8%.
-⬥ Invigorating <:invig4:712073087859949570> can be comboed with several things, this can allow for a Mobile <:mob:689501908628799488> switch for Greater Barge <:gbarge:535532879250456578> when you want the shorter cooldown.
+⬥ Invigorating <:invig4:712073087859949570> can be combo-ed with several things, which allows for a Mobile <:mob:689501908628799488> switch for Greater Barge <:gbarge:535532879250456578> when you want the shorter cooldown.
 ⬥ Most impactful for Magic <:Magic:689504724159823906> setups but can be beneficial for all if you use Freedom <:freedom:535541258240786434> a lot.
 
 .


### PR DESCRIPTION
Lines 3, 104: Improved sentence structure
Lines 12, 32: Substituted "flank" for "flanking", as weapons with the flanking perk on them are generally referred to as a flanking switch rather than a flank switch. 
Lines 20, 39, 53, 70, 83, 99: Fixed grammatical errors
Lines 25,39, 47,65, 104: Fixed punctuation errors
Lines 72, 92: Substituted "us" for "you" , as majority of PVME writeups are written from the perspective of a person referring to the reader, instead of a person referring to themselves and the reader.