### PR TITLE
Update eof-specs.txt

### DIFF
--- a/miscellaneous-information/eof-specs.txt
+++ b/miscellaneous-information/eof-specs.txt
@@ -106,7 +106,7 @@ The Essence of Finality <:eof:787526151978614824> <:eofor:745279787471470713> is
 ⬥ Special Attack: __Gravitate__
     • Costs 60% adrenaline
     • When used, for 30 seconds all successful attacks on your opponent(s) adds a stack, which increases your damage by 1% per stack, capping at 20%
-    • Stacks are cleared if: the effect's timer runs out, you switch weapons, if the special attack is used again within 30 seconds
+    • The special attack will clear itself prematurely if: you switch weapons, you splash on any target, or if the special attack is used again within 30 seconds
     • Functionally useless, as you can just use DBA <:DBA:603979368850653216> spec and get a similar buff for a minute
 ⬥ What <:eofspec:746403211908481184> lets you do that you normally cannot
     • A lasting damage amplifier that allows you to be mobile


### PR DESCRIPTION
Changed Annihilation text; added spec clearing when splashing and reworded "stacks clearing" as it could be misleading (may give people the idea that the stacks reset to 0 but the spec remains active which is not the case). 