### PR TITLE
Fixed typo in Vorago tips and tricks

### DIFF
--- a/high-tier-pvm/vorago-tips-and-tricks.txt
+++ b/high-tier-pvm/vorago-tips-and-tricks.txt
@@ -288,7 +288,7 @@ Cooldowns go around 360 degrees on your abilities clockwise, and keeping clocks 
 .
 .img:https://i.imgur.com/64bHib9.png
 .
-> **__Centering Vorago__ (Courtesy of <@!414995552393232394> and <@175995416955977728>)**
+> **__Centring Vorago__ (Courtesy of <@!414995552393232394> and <@175995416955977728>)**
 .tag:centre
 Knowing how to walk Vorago is useful for moving him on phase 2. 
 


### PR DESCRIPTION
Changed "Centering Vorago" to "Centring Vorago" as "Centring" is the correct spelling in British English and consistent with the Table of Contents.