### PR TITLE
Updates for upgrade order

### DIFF
--- a/upgrading-info/upgrade-order.txt
+++ b/upgrading-info/upgrade-order.txt
@@ -17,20 +17,26 @@ You should also feel free to buy items that are stated as less important in the 
 .
 > __**Magic**__
 .tag:magic
+Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
+.
 **__Assuming T70 Start__**
 ⬥ Guthix Staff <:gstaff:513203008608141314>
 ⬥ Sunshine <:Sunshine:583430011948630016>
 ⬥ Cywir Wand + Virtus Book/Superior Zuriel's Staff <:cywirwand:643161591571021824> <:vbook:656785078160195615> / <:zstaff:797895640154636328>
 ⬥ Entry Level Perks <:ancientweapongizmo:697405383752548382> <:ancientarmourgizmo:697405383769194516>
 ⬥ Corruption Blast <:corruptblast:513190159194259467>
+    • Skip if planning to do content where several people are using the same style
 ⬥ T90 Weapon <:noxstaff:513190159294922753> <:seiswand:583429704837758997>
 ⬥ Planted Feet <:pf:689501925770919981>
 ⬥ T88 Armour + Celestial Handwraps <:SuperiorZurielstop:556586037216804864> <:Celestialhandwraps:513190158716239885>
 ⬥ Blast Diffusion Boots <:detoboots:602581956072439828>
 ⬥ Seismic Singularity <:seissing:583430011831189527>
 ⬥ Off-hand Flanking 4 Switch <:vbook:656785078160195615> <:flank4:712073088296157185>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
 ⬥ Inquisitor Staff <:inquisitorstaff:694566917553520680>
 ⬥ Essence of Finality <:eofpurple:780401412936040478> (adding guthix staff <:gstaff:513203008608141314> is recommended)
+.
 ⬥ Biting 4 <:biting4:712073087809617931>
 ⬥ Limitless <:limitless:641339233638023179>
 ⬥ Affliction <:Affliction:513190158468907008>
@@ -39,13 +45,23 @@ You should also feel free to buy items that are stated as less important in the 
 ⬥ Upgrade to T92 Armour <:elitetectbody:552955120707698699>
 ⬥ Imperium Core <:impercore:643166751067996160>
 ⬥ Upgrade to T90 Flanking 4 switch <:seissing:583430011831189527> <:flank4:712073088296157185>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
 ⬥ Seren Godbow + Ingenuity of the Humans <:sgb:626466665848242186> <:ingen:641339234111848463>
+    • Skip if not planning to do bosses of size 5x5 or greater
 ⬥ Staff of Sliske <:Sos:626466320132734976>
+    • Skip if planning to do content where Inquisitor Staff <:inquisitorstaff:694566917553520680> works
 ⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+.
+Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
 
 .
 > __**Range**__
 .tag:range
+Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
+.
 **__Assuming T70 Start__**
 ⬥ Death's Swiftness <:ds:535541258924326912>
 ⬥ Royal Crossbow <:royalcrossbow:798285340439871558>
@@ -53,50 +69,77 @@ You should also feel free to buy items that are stated as less important in the 
 ⬥ Entry Level Perks <:ancientweapongizmo:697405383752548382> <:ancientarmourgizmo:697405383769194516>
 ⬥ Ascensions <:ascmh:513190158468775936> <:ascoh:513190159362031631>
 ⬥ Corruption Shot <:corruptshot:535541306294796299>
+    • Skip if planning to do content where several people are using the same style
 ⬥ Planted Feet <:pf:689501925770919981>
 ⬥ T90 Armour + Pernix gloves/boots <:sirenicbody:643846948570267648> <:Pernixgloves:556588696510529555>
 ⬥ Biting 4 <:biting4:712073087809617931>
 ⬥ An off-hand Flanking 4 switch <:flank4:712073088296157185>
-⬥ Essence of Finality <:eofgreen:780401412727242773>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+⬥ Essence of Finality <:eofgreen:780401412727242773> (adding a Dark Bow <:dbow:643848618553507843> is recommended)
 ⬥ Greater Ricochet + Caroming 4 <:grico:787904334812807238> <:caroming4:791281588792590336>
 ⬥ Seren Godbow <:sgb:626466665848242186>
+    • Skip if not planning to do bosses of size 3x3 or greater OR if not comfortable losing inventory space to off-style SGB
 ⬥ Eldritch Crossbow + Caroming 4 Equilibrium 2 <:ecb:615618531937222657> <:caroming4:791281588792590336> <:eq2:689502258424971564>
 .
 ⬥ Desolation <:Desolation:513190159018098713>
 ⬥ Limitless <:limitless:641339233638023179>
 ⬥ P6AS1 + AS4E2 (or P6R1 on 2h) <:p6:712073088769982475><:as1:689502339891331093> <:as4:712074245202772009><:eq2:689502258424971564> <:ruthless1:712244800924942396> 
 ⬥ Seren Godbow (Essence of Finality) <:sgb:626466665848242186> <:eofblue:780401412906680330>
+    • Skip if not planning to do bosses of size 3x3 or greater OR if not comfortable losing inventory space to off-style SGB
 ⬥ Blightbound Crossbows <:bbc:626714879218155521> <:bbcoh:626714879230738434>
 ⬥ Upgrade to T90 Caroming 4 switch <:ascoh:513190159362031631><:caroming4:791281588792590336> + Eldritch Crossbow (Essence of Finality) <:ecb:615618531937222657>  <:eofpink:780401412865523722>
+    • Skip until 2nd ECB if planning to do Nex <:Nex:513213159071547395>
 ⬥ Fleeting Boots <:fleetingboots:789813993480388640>
 ⬥ Upgrade to T90 Flanking 4 switch <:barrowsascoh:580176856968331277> <:flank4:712073088296157185>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
 ⬥ Upgrade to T92 Armour <:elitesirenicbody:643846908305211413>
 ⬥ Upgrade to T92 Caroming 4 switch <:barrowsbbcoh:580176857123651584> <:caroming4:791281588792590336>
 ⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+.
+Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
 
 .
 > __**Melee**__
 .tag:melee
+Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
+.
 **__Assuming T70 Start__**
 ⬥ Blade of Nymora + off-hand Ripper claw/Masuta's Warspear <:nymorablade:643161612819365888> <:ripperclaw:797895640054759444> / <:masutaspear:643166903220699137>
-⬥ Scythe AND/OR Drygores <:noxscythe:513190159341322240> <:augdrygoremacemh:697485495684431902> <:augdrygorerapieroh:697485495718117536>
+⬥ Drygores <:augdrygoremacemh:697485495684431902> <:augdrygorerapieroh:697485495718117536>
 ⬥ Entry Level Perks <:ancientweapongizmo:697405383752548382> <:ancientarmourgizmo:697405383769194516>
+⬥ Scythe OR Masterwork Spear of Annihilation <:noxscythe:513190159341322240> / <:masterworkspearofannihilation:694566917456789554> with Entry Level Perks <:ancientweapongizmo:697405383752548382>
+    • Opt for Scythe if you plan to do AoE content, or if you require the extra range, Spear otherwise
+⬥ Strength Skillcape <:strcape:689503815296352308>
+    • Primarily beneficial for extended Dismember <:dismember:535532879376023572> duration
 ⬥ T90 Armour <:malevbody:643846996842512405>
 ⬥ Laceration Boots <:Laceration:602581988599398400>
 ⬥ Greater Barge <:gbarge:535532879250456578>
 ⬥ Greater Flurry <:gflurry:535532879283879977>
+    • Skip if planning to do AoE-based content
 ⬥ Biting 4 <:biting4:712073087809617931>
-⬥ An off-hand t90 Flanking 4 Switch. <:flank4:712073088296157185>
-⬥ Zaros Godsword <:zgs:626465964325601290>
-⬥ Masterwork Spear of Annihilation + Strength Skillcape <:masterworkspearofannihilation:694566917456789554> <:strcape:689503815296352308>
-⬥ Essence of Finality <:eofred:780401412839833601>
-⬥ Malevolence <:Malevolence:513190159416557573>
 ⬥ Limitless <:limitless:641339233638023179>
+⬥ An off-hand t90 Flanking 4 Switch. <:flank4:712073088296157185>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+.
+⬥ Zaros Godsword <:zgs:626465964325601290>
+⬥ Masterwork Spear of Annihilation + Lunging <:lunge4:736522494315593759>
+    • If you did not get this before, get it here
+        - If you got it before, add lunging to it here
+    • Skip if planning to do content where several people are using the same style
+⬥ Essence of Finality <:eofred:780401412839833601> (adding Dragon Claws <:dragonclaw:779048041088024606> <:dragonclawoh:779048040865726485> is recommended)
+⬥ Malevolence <:Malevolence:513190159416557573>
 ⬥ P6AS1 + AS4E2 (or P6R1 on 2h) <:p6:712073088769982475><:as1:689502339891331093> <:as4:712074245202772009><:eq2:689502258424971564> <:ruthless1:712244800924942396>
 ⬥ Custom Fitted Trimmed Masterwork <:tmwbody:536966366272552960>
 ⬥ Khopesh <:khopeshmh:513206794844110858> <:khopeshoh:513206794752098327>
 ⬥ Greater Fury <:gfury:535532879334080527>
 ⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+.
+Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
 
 .
 > **__Common Mistakes to Avoid__ (Courtesy of <@135502088049393664>)**

--- a/upgrading-info/upgrade-order.txt
+++ b/upgrading-info/upgrade-order.txt
@@ -17,23 +17,24 @@ You should also feel free to buy items that are stated as less important in the 
 .
 > __**Magic**__
 .tag:magic
-Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
-Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
-.
+**Disclaimer 1:** This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+
+**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689234925064290323>, or <#797160458980950029>.
+
+.tag:disclaimer1
 **__Assuming T70 Start__**
 ⬥ Guthix Staff <:gstaff:513203008608141314>
 ⬥ Sunshine <:Sunshine:583430011948630016>
 ⬥ Cywir Wand + Virtus Book/Superior Zuriel's Staff <:cywirwand:643161591571021824> <:vbook:656785078160195615> / <:zstaff:797895640154636328>
 ⬥ Entry Level Perks <:ancientweapongizmo:697405383752548382> <:ancientarmourgizmo:697405383769194516>
 ⬥ Corruption Blast <:corruptblast:513190159194259467>
-    • Skip if planning to do content where several people are using the same style
 ⬥ T90 Weapon <:noxstaff:513190159294922753> <:seiswand:583429704837758997>
 ⬥ Planted Feet <:pf:689501925770919981>
 ⬥ T88 Armour + Celestial Handwraps <:SuperiorZurielstop:556586037216804864> <:Celestialhandwraps:513190158716239885>
 ⬥ Blast Diffusion Boots <:detoboots:602581956072439828>
 ⬥ Seismic Singularity <:seissing:583430011831189527>
 ⬥ Off-hand Flanking 4 Switch <:vbook:656785078160195615> <:flank4:712073088296157185>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 ⬥ Inquisitor Staff <:inquisitorstaff:694566917553520680>
 ⬥ Essence of Finality <:eofpurple:780401412936040478> (adding guthix staff <:gstaff:513203008608141314> is recommended)
 .
@@ -41,27 +42,31 @@ Disclaimer 2: For further information on each upgrade check the relevant section
 ⬥ Limitless <:limitless:641339233638023179>
 ⬥ Affliction <:Affliction:513190158468907008>
 ⬥ P6AS1 + AS4E2 (or P6R1 on staff) <:p6:712073088769982475><:as1:689502339891331093> <:as4:712074245202772009><:eq2:689502258424971564> <:ruthless1:712244800924942396>
+*Note: AS4 is a very strong perk in its own right. If you fail going for AS4E2, feel free to use AS4 in its place for the time being.*
 ⬥ Wand of the Praesul <:praeswand:643166769518739477>
 ⬥ Upgrade to T92 Armour <:elitetectbody:552955120707698699>
 ⬥ Imperium Core <:impercore:643166751067996160>
 ⬥ Upgrade to T90 Flanking 4 switch <:seissing:583430011831189527> <:flank4:712073088296157185>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
-⬥ Seren Godbow + Ingenuity of the Humans <:sgb:626466665848242186> <:ingen:641339234111848463>
-    • Skip if not planning to do bosses of size 5x5 or greater
-⬥ Staff of Sliske <:Sos:626466320132734976>
-    • Skip if planning to do content where Inquisitor Staff <:inquisitorstaff:694566917553520680> works
-⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you*
 .
-Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
-Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
+⬥ Seren Godbow + Ingenuity of the Humans <:sgb:626466665848242186> <:ingen:641339234111848463>
+*Note: Skip if not planning to do bosses of size 5x5 or greater.*
+⬥ Staff of Sliske <:Sos:626466320132734976>
+*Note: Skip if planning to do content where Inquisitor Staff <:inquisitorstaff:694566917553520680> works.*
+⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you*
+
+.
+**Reminder** - $linkmsg_disclaimer1$
 
 .
 > __**Range**__
 .tag:range
-Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
-Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
-.
+**Disclaimer 1:** This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+
+**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689234925064290323>, or <#797160458980950029>.
+
+.tag:disclaimer2
 **__Assuming T70 Start__**
 ⬥ Death's Swiftness <:ds:535541258924326912>
 ⬥ Royal Crossbow <:royalcrossbow:798285340439871558>
@@ -69,77 +74,84 @@ Disclaimer 2: For further information on each upgrade check the relevant section
 ⬥ Entry Level Perks <:ancientweapongizmo:697405383752548382> <:ancientarmourgizmo:697405383769194516>
 ⬥ Ascensions <:ascmh:513190158468775936> <:ascoh:513190159362031631>
 ⬥ Corruption Shot <:corruptshot:535541306294796299>
-    • Skip if planning to do content where several people are using the same style
+.
 ⬥ Planted Feet <:pf:689501925770919981>
 ⬥ T90 Armour + Pernix gloves/boots <:sirenicbody:643846948570267648> <:Pernixgloves:556588696510529555>
 ⬥ Biting 4 <:biting4:712073087809617931>
 ⬥ An off-hand Flanking 4 switch <:flank4:712073088296157185>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
+.
 ⬥ Essence of Finality <:eofgreen:780401412727242773> (adding a Dark Bow <:dbow:643848618553507843> is recommended)
 ⬥ Greater Ricochet + Caroming 4 <:grico:787904334812807238> <:caroming4:791281588792590336>
 ⬥ Seren Godbow <:sgb:626466665848242186>
-    • Skip if not planning to do bosses of size 3x3
+*Note: Skip if not planning to do bosses of size 3x3.*
 ⬥ Eldritch Crossbow + Caroming 4 Equilibrium 2 <:ecb:615618531937222657> <:caroming4:791281588792590336> <:eq2:689502258424971564>
 .
 ⬥ Desolation <:Desolation:513190159018098713>
 ⬥ Limitless <:limitless:641339233638023179>
 ⬥ P6AS1 + AS4E2 (or P6R1 on 2h) <:p6:712073088769982475><:as1:689502339891331093> <:as4:712074245202772009><:eq2:689502258424971564> <:ruthless1:712244800924942396> 
+*Note: AS4 is a very strong perk in its own right. If you fail going for AS4E2, feel free to use AS4 in its place for the time being.*
 ⬥ Seren Godbow (Essence of Finality) <:sgb:626466665848242186> <:eofblue:780401412906680330>
-    • Skip if not planning to do bosses of size 3x3 or greater OR if not comfortable losing inventory space to off-style SGB
+*Note: Skip if not planning to do bosses of size 3x3 or greater OR if not comfortable losing inventory space to off-style SGB.*
+⬥ Fleeting Boots <:fleetingboots:789813993480388640>
+*Note: In most encounters these are strictly a quality of life upgrade and can typically be skipped*
 ⬥ Blightbound Crossbows <:bbc:626714879218155521> <:bbcoh:626714879230738434>
 ⬥ Upgrade to T90 Caroming 4 switch <:ascoh:513190159362031631><:caroming4:791281588792590336> + Eldritch Crossbow (Essence of Finality) <:ecb:615618531937222657>  <:eofpink:780401412865523722>
-    • Skip until 2nd ECB if planning to do Nex <:Nex:513213159071547395>
-⬥ Fleeting Boots <:fleetingboots:789813993480388640>
+*Note: Skip until 2nd ECB if planning to do Nex <:Nex:513213159071547395>.*
+.
 ⬥ Upgrade to T90 Flanking 4 switch <:barrowsascoh:580176856968331277> <:flank4:712073088296157185>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 ⬥ Upgrade to T92 Armour <:elitesirenicbody:643846908305211413>
 ⬥ Upgrade to T92 Caroming 4 switch <:barrowsbbcoh:580176857123651584> <:caroming4:791281588792590336>
 ⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
+
 .
-Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
-Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
+**Reminder** - $linkmsg_disclaimer2$
 
 .
 > __**Melee**__
 .tag:melee
-Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
-Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
-.
+**Disclaimer 1:** This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
+
+**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689234925064290323>, or <#797160458980950029>.
+
+.tag:disclaimer3
 **__Assuming T70 Start__**
 ⬥ Blade of Nymora + off-hand Ripper claw/Masuta's Warspear <:nymorablade:643161612819365888> <:ripperclaw:797895640054759444> / <:masutaspear:643166903220699137>
 ⬥ Drygores <:augdrygoremacemh:697485495684431902> <:augdrygorerapieroh:697485495718117536>
 ⬥ Entry Level Perks <:ancientweapongizmo:697405383752548382> <:ancientarmourgizmo:697405383769194516>
 ⬥ Scythe OR Masterwork Spear of Annihilation <:noxscythe:513190159341322240> / <:masterworkspearofannihilation:694566917456789554> with Entry Level Perks <:ancientweapongizmo:697405383752548382>
-    • Opt for Scythe if you plan to do AoE content, or if you require the extra range, Spear otherwise
+*Note: Opt for Scythe if you plan to do AoE content, or if you require the extra range, Spear otherwise.*
+.
 ⬥ Strength Skillcape <:strcape:689503815296352308>
-    • Primarily beneficial for extended Dismember <:dismember:535532879376023572> duration
+*Note: Primarily beneficial for extended Dismember <:dismember:535532879376023572> duration.*
 ⬥ T90 Armour <:malevbody:643846996842512405>
 ⬥ Laceration Boots <:Laceration:602581988599398400>
 ⬥ Greater Barge <:gbarge:535532879250456578>
 ⬥ Greater Flurry <:gflurry:535532879283879977>
-    • Skip if planning to do AoE-based content
+.
 ⬥ Biting 4 <:biting4:712073087809617931>
 ⬥ Limitless <:limitless:641339233638023179>
 ⬥ An off-hand t90 Flanking 4 Switch. <:flank4:712073088296157185>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 .
 ⬥ Zaros Godsword <:zgs:626465964325601290>
-⬥ Masterwork Spear of Annihilation + Lunging <:lunge4:736522494315593759>
-    • If you did not get this before, get it here
-        - If you got it before, add lunging to it here
-    • Skip if planning to do content where several people are using the same style
+⬥ Masterwork Spear of Annihilation + Lunging <:masterworkspearofannihilation:694566917456789554> <:lunge4:736522494315593759>
+*Note: If you did not get this before, get it here; however, if planning to do content where several people will be using melee, skip entirely. If you got it before, add lunging to it here.*
+.
 ⬥ Essence of Finality <:eofred:780401412839833601> (adding Dragon Claws <:dragonclaw:779048041088024606> <:dragonclawoh:779048040865726485> is recommended)
 ⬥ Malevolence <:Malevolence:513190159416557573>
 ⬥ P6AS1 + AS4E2 (or P6R1 on 2h) <:p6:712073088769982475><:as1:689502339891331093> <:as4:712074245202772009><:eq2:689502258424971564> <:ruthless1:712244800924942396>
+*Note: AS4 is a very strong perk in its own right. If you fail going for AS4E2, feel free to use AS4 in its place for the time being.*
 ⬥ Custom Fitted Trimmed Masterwork <:tmwbody:536966366272552960>
 ⬥ Khopesh <:khopeshmh:513206794844110858> <:khopeshoh:513206794752098327>
 ⬥ Greater Fury <:gfury:535532879334080527>
 ⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
-    • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you
+*Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
+
 .
-Disclaimer 1: This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
-Disclaimer 2: For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, or <#797160458980950029>
+**Reminder** - $linkmsg_disclaimer3$
 
 .
 > **__Common Mistakes to Avoid__ (Courtesy of <@135502088049393664>)**

--- a/upgrading-info/upgrade-order.txt
+++ b/upgrading-info/upgrade-order.txt
@@ -78,7 +78,7 @@ Disclaimer 2: For further information on each upgrade check the relevant section
 ⬥ Essence of Finality <:eofgreen:780401412727242773> (adding a Dark Bow <:dbow:643848618553507843> is recommended)
 ⬥ Greater Ricochet + Caroming 4 <:grico:787904334812807238> <:caroming4:791281588792590336>
 ⬥ Seren Godbow <:sgb:626466665848242186>
-    • Skip if not planning to do bosses of size 3x3 or greater OR if not comfortable losing inventory space to off-style SGB
+    • Skip if not planning to do bosses of size 3x3
 ⬥ Eldritch Crossbow + Caroming 4 Equilibrium 2 <:ecb:615618531937222657> <:caroming4:791281588792590336> <:eq2:689502258424971564>
 .
 ⬥ Desolation <:Desolation:513190159018098713>

--- a/upgrading-info/upgrade-order.txt
+++ b/upgrading-info/upgrade-order.txt
@@ -53,7 +53,7 @@ You should also feel free to buy items that are stated as less important in the 
 *Note: Skip if not planning to do bosses of size 5x5 or greater.*
 ⬥ Staff of Sliske <:Sos:626466320132734976>
 *Note: Skip if planning to do content where Inquisitor Staff <:inquisitorstaff:694566917553520680> works.*
-⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185><:eq1:689504357414207490>
 *Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you*
 
 .
@@ -96,14 +96,14 @@ You should also feel free to buy items that are stated as less important in the 
 ⬥ Fleeting Boots <:fleetingboots:789813993480388640>
 *Note: In most encounters these are strictly a quality of life upgrade and can typically be skipped*
 ⬥ Blightbound Crossbows <:bbc:626714879218155521> <:bbcoh:626714879230738434>
-⬥ Upgrade to T90 Caroming 4 switch <:ascoh:513190159362031631><:caroming4:791281588792590336> + Eldritch Crossbow (Essence of Finality) <:ecb:615618531937222657>  <:eofpink:780401412865523722>
+⬥ Upgrade to T90 Caroming 4 switch <:ascoh:513190159362031631> <:caroming4:791281588792590336> + Eldritch Crossbow (Essence of Finality) <:ecb:615618531937222657> <:eofpink:780401412865523722>
 *Note: Skip until 2nd ECB if planning to do Nex <:Nex:513213159071547395>.*
 .
 ⬥ Upgrade to T90 Flanking 4 switch <:barrowsascoh:580176856968331277> <:flank4:712073088296157185>
 *Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 ⬥ Upgrade to T92 Armour <:elitesirenicbody:643846908305211413>
 ⬥ Upgrade to T92 Caroming 4 switch <:barrowsbbcoh:580176857123651584> <:caroming4:791281588792590336>
-⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185><:eq1:689504357414207490>
 *Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 
 .
@@ -133,7 +133,7 @@ You should also feel free to buy items that are stated as less important in the 
 .
 ⬥ Biting 4 <:biting4:712073087809617931>
 ⬥ Limitless <:limitless:641339233638023179>
-⬥ An off-hand t90 Flanking 4 Switch. <:flank4:712073088296157185>
+⬥ An off-hand t90 Flanking 4 Switch <:augdrygorerapieroh:697485495718117536> <:flank4:712073088296157185>
 *Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 .
 ⬥ Zaros Godsword <:zgs:626465964325601290>
@@ -147,7 +147,7 @@ You should also feel free to buy items that are stated as less important in the 
 ⬥ Custom Fitted Trimmed Masterwork <:tmwbody:536966366272552960>
 ⬥ Khopesh <:khopeshmh:513206794844110858> <:khopeshoh:513206794752098327>
 ⬥ Greater Fury <:gfury:535532879334080527>
-⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
+⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185><:eq1:689504357414207490>
 *Note: Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.*
 
 .

--- a/upgrading-info/upgrade-order.txt
+++ b/upgrading-info/upgrade-order.txt
@@ -19,7 +19,7 @@ You should also feel free to buy items that are stated as less important in the 
 .tag:magic
 **Disclaimer 1:** This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
 
-**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689234925064290323>, or <#797160458980950029>.
+**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689236456698675263>, or <#797160458980950029>.
 
 .tag:disclaimer1
 **__Assuming T70 Start__**
@@ -64,7 +64,7 @@ You should also feel free to buy items that are stated as less important in the 
 .tag:range
 **Disclaimer 1:** This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
 
-**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689234925064290323>, or <#797160458980950029>.
+**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689236456698675263>, or <#797160458980950029>.
 
 .tag:disclaimer2
 **__Assuming T70 Start__**
@@ -114,7 +114,7 @@ You should also feel free to buy items that are stated as less important in the 
 .tag:melee
 **Disclaimer 1:** This is a generalized order, if you would like specialized advice ask in <#656898197561802760> or <#820151918818492416>
 
-**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689234925064290323>, or <#797160458980950029>.
+**Disclaimer 2:** For further information on each upgrade check the relevant section in <#689235882724818962>, <#553632787639435284> and <#689236234912137266>, <#689236456698675263>, or <#797160458980950029>.
 
 .tag:disclaimer3
 **__Assuming T70 Start__**


### PR DESCRIPTION
Did the changes agreed to in senior editor:
• Added sub-notes to more situational things for if you should skip or not
• Moved Scythe after Gores + Entry perks, moved spear earlier there too as an alt. option both with entry level perks depending on what is chosen. Also left spear in its normal slot later on
• Moved Str Cape earlier too, directly after the spear/scythe is bought
• Added "recommend dbow" to pair with green eof
• Added "recommend dclaws" to pair with red eof

Also:
• Moved limitless from after t90 f4 to after b4 for melee (Feel free to revert if disagree)