### PR TITLE
changed tl;dr of !blights command

### DIFF
--- a/commands/blights.txt
+++ b/commands/blights.txt
@@ -1,4 +1,4 @@
-__**Tl;dr: Cost does not outweight the setback and gains**__
+__**Tl;dr: The gains do not outweight the cost nor how much it sets you back from other upgrades**__
 
 Blightbounds are low priority as the cost for the slight tier increase over ascensions does not matter as much due to your primary damage output coming as a result of Bakriminel Bolts.
 


### PR DESCRIPTION
• went from: "Cost does not outweight the setback and gains" to "The gains do not outweight the cost nor how much it sets you back from other upgrades"
    - Realized logic of the former was messed up, wording can imply that the cost is worth it, also was just unclear english to read really