### PR TITLE
Fixed typos in vorago-tips-and-tricks

### DIFF
--- a/vorago/vorago-tips-and-tricks.txt
+++ b/vorago/vorago-tips-and-tricks.txt
@@ -457,7 +457,7 @@ Xlogging may be used at the end of the kill to forfeit drop piles to other teamm
 
 .
 **__How to Xlog__**
-Shield dome prior to mauling on p5 (normal mode) or p11 (hard mode). Once the mauling animation begins, qiuck hop worlds through friends list, your piles will be rerolled to remaining members. 
+Shield Dome prior to mauling on p5 (normal mode) or p11 (hard mode). Once the mauling animation begins, quick hop worlds through friends list, your piles will be rerolled to remaining members. 
 
 .
 > **__Table of Contents__**


### PR DESCRIPTION
"Shield dome" -> "Shield Dome", "qiuck" -> "quick"