### PR TITLE
teamforming command change

### DIFF
--- a/commands/teamforming.txt
+++ b/commands/teamforming.txt
@@ -1,7 +1,7 @@
 {
     "embed": {
         "color": 50886,
-        "description": "Affilliates for teamforming!",
+        "description": "PvmE is dedicated to providing info, not teamforming. For teamforming check out our affiliates below:",
         "title": "Teamforming Servers",
         "fields": [
             {


### PR DESCRIPTION
• updated description from: "Affilliates for teamforming!" to "PvmE is dedicated to providing info, not teamforming. For teamforming check out our affiliates below:"