### PR TITLE
various channel fixes/updates

### DIFF
--- a/dpm-advice/dpm-advice-mage.txt
+++ b/dpm-advice/dpm-advice-mage.txt
@@ -361,7 +361,6 @@ In RuneScape PvM, the meta at the time of writing is about pushing out as much d
     • It is affected by Blast Diffusion Boots <:detoboots:602581956072439828>:
         - It takes 4t (2.4s) to reach 100% instead of 6t (3.6s)
         - It gains 40% charge at a time instead of 20%.
-    • Channelled ability
 
 .
 **__Special Attacks__**
@@ -417,7 +416,7 @@ Refer to this table for hit timings of each ability
 > **__Cancelling Channels__**
 .tag:Cancel
 **__Why to Cancel__**
-⬥ Magic has 4 channeled abilities, but this section will only apply to 3 as they are more traditional channels
+⬥ Magic has 3 channeled abilities
     • These 3 are: Concentrated Blast <:conc:535533833106489365>, Asphyxiate <:asphyx:535533833072672778>, and Smoke Tendrils <:Smoke_Tendrils:536257336130404372>
 
 .
@@ -444,16 +443,17 @@ https://www.youtube.com/watch?v=unCtj7IosVA
 > **__Detonate__**
 .tag:Deto
 **__What Makes Detonate Unique__**
-⬥ As mentioned, Magic has 4 channels, 3 of which were mentioned prior, this section will be dedicated to Detonate <:deto:535533833358016512> due to how differently it works compared to other channels
+⬥ As mentioned, Magic has 3 channels; however, Detonate is often considered one too even if it technically is not one due to the need to charge it. This section will be dedicated to Detonate <:deto:535533833358016512> due to how differently it works compared to normal channels.
 
 .
-⬥ Unlike most channels Detonate <:deto:535533833358016512> acts like or can have the following done within it:
+⬥ Unlike other channels, Detonate <:deto:535533833358016512> acts like or can have the following done within it:
     • It acts somehwat like a defensive in the context of defensive autos (you can release Detonate <:deto:535533833358016512> with an Auto <:AirSurge:543465115870035999> given the Auto <:AirSurge:543465115870035999> is not on cooldown)
     • You can throw Vulnerability Bombs <:vulnbomb:655341074235129858> during its charge time
     • You can SBS <:SBSLunars:565726489467682816> <:SBSStandards:565726489526534154> during its charge time
     • You can Shield Dome during its charge time
     • You can stall its release
         - Generally speaking you cannot stall channels (outside of melees wherein only 1 hit is stalled)
+    • It is not affected by the Channeller's Ring <:channellerring:839903943404027914> due to not actually being a channeled ability
 
 .
 ⬥ Typically, when releasing Detonate <:deto:535533833358016512> you will release it with an Auto and an Ability

--- a/mid-tier-pvm/vindicta.txt
+++ b/mid-tier-pvm/vindicta.txt
@@ -225,7 +225,7 @@ https://youtu.be/oNOEKg_1Fgc
 ⬥ <:persistentrage:739965637056659567> **Persistent Rage Relic** - Prevents adrenaline from draining while out of combat. Can be substituted with an **Adrenaline Urn** <:adrenurn:656426717413507074> with ocassional stalling.
 ⬥ **Ganodermic Gloves & Boots** - Magic tank armor is required for **Animate Dead** <:animatedead:856635090453135382> to reduce enough damage for this afk method. This is the cheapest and most effective option at this moment.
 ⬥ <:runepouch:583430011868938283> **Runes** - Runes are of course required to cast Animate Dead. The runes you should bring are: <:Soulrune:536252660333019136>, <:Bloodrune:536252658970001409>, <:Deathrune:536252659586433024>, <:Earthrune:536252659808731137>.
-⬥ <:eof:787526151978614824> **Essence of Finality** - Stored special attack is not used, but is worn for the accuracy bonus and Soulsplit passive.
+⬥ <:eof:787526151978614824> **Essence of Finality** - Stored special attack is not used, but is worn for the accuracy bonus and protection prayer passive.
 ⬥ <:championring:839903943630520350> **Champion's Ring** - Extra critical chance helps speed up kills. If not owned, can be substituted for other strong rings such as Asylum Surgeon's <:asr:513190158472839208> or Ring of Death. <:RoD:513190159462825984>
 .
 .img:https://i.imgur.com/Z5RlJ24.png

--- a/miscellaneous-information/auto-attacks.txt
+++ b/miscellaneous-information/auto-attacks.txt
@@ -247,7 +247,7 @@ T7: Ability
         - If you wanted to change what the 2H auto is, you would have to 3 tick it.
     • If you wanted to change what the off-hand auto is for Melee or Range (i.e., to replace the auto for some specific spell), to cast the spell you are required to equip an off-hand magic weapon such as an Ancient Lantern <:ancientlantern:580177522503712781>.
         - It is important to note that you must have an off-hand auto cast set, because of this it is recommended to use Polypore Strike as it can be accessed on all books, which allows you to Spellbook Swap <:SBS:543875425055670275> between books without issue.
-        - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it
+        - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it.
 
 .
 **__Delaying Defensive Auto__**

--- a/miscellaneous-information/auto-attacks.txt
+++ b/miscellaneous-information/auto-attacks.txt
@@ -247,7 +247,7 @@ T7: Ability
         - If you wanted to change what the 2H auto is, you would have to 3 tick it.
     • If you wanted to change what the off-hand auto is for Melee or Range (i.e., to replace the auto for some specific spell), to cast the spell you are required to equip an off-hand magic weapon such as an Ancient Lantern <:ancientlantern:580177522503712781>.
         - It is important to note that you must have an off-hand auto cast set, because of this it is recommended to use Polypore Strike as it can be accessed on all books, which allows you to Spellbook Swap <:SBS:543875425055670275> between books without issue.
-       - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it
+        - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it
 
 .
 **__Delaying Defensive Auto__**

--- a/miscellaneous-information/auto-attacks.txt
+++ b/miscellaneous-information/auto-attacks.txt
@@ -243,9 +243,11 @@ T7: Ability
 
 .
 ⬥ It is important to note that Freedom <:freedom:535541258240786434> works a little differently, in that you will get both an off-hand and a main-hand/2H auto
-    • You will always get the off-hand auto, and what is cast as an off-hand auto can be changed by casting the auto before, but on the same tick, as Freedom <:freedom:535541258240786434> <:sing:513190159261630467>.
-        - If you wanted to change what the off-hand auto is for Melee or Ranged, i.e., to replace the auto for some spell, to cast the spell you are required to equip an off-hand magic weapon such as a Seismic Singularity <:sing:513190159261630467>.
+    • You will always get the off-hand auto, and what is cast as an off-hand auto can be changed by casting the auto before, but on the same tick, as Freedom <:freedom:535541258240786434>.
         - If you wanted to change what the 2H auto is, you would have to 3 tick it.
+    • If you wanted to change what the off-hand auto is for Melee or Range (i.e., to replace the auto for some specific spell), to cast the spell you are required to equip an off-hand magic weapon such as an Ancient Lantern <:ancientlantern:580177522503712781>.
+        - It is important to note that you must have an off-hand auto cast set, because of this it is recommended to use Polypore Strike as it can be accessed on all books, which allows you to Spellbook Swap <:SBS:543875425055670275> between books without issue.
+      - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it
 
 .
 **__Delaying Defensive Auto__**
@@ -293,7 +295,7 @@ T6: 2H Auto + Ability
     • Though in the case of maximizing adrenaline gain when building you would want to exploit as many as possible as you will generate more adrenaline overall as compared to normal abilities due to you getting the Auto adrenaline ontop of the normal abilities adrenaline gains
 
 .
-> **__Application: 4tAA__**
+> **__Application: 4TAA__**
 .tag:4TAA
 *Note: Any time you see a speed before an Auto or Ability, such as "Average Ability," that is simply referring to the weapon speed of the weapon used to cast it*
 

--- a/miscellaneous-information/auto-attacks.txt
+++ b/miscellaneous-information/auto-attacks.txt
@@ -247,7 +247,7 @@ T7: Ability
         - If you wanted to change what the 2H auto is, you would have to 3 tick it.
     • If you wanted to change what the off-hand auto is for Melee or Range (i.e., to replace the auto for some specific spell), to cast the spell you are required to equip an off-hand magic weapon such as an Ancient Lantern <:ancientlantern:580177522503712781>.
         - It is important to note that you must have an off-hand auto cast set, because of this it is recommended to use Polypore Strike as it can be accessed on all books, which allows you to Spellbook Swap <:SBS:543875425055670275> between books without issue.
-      - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it
+       - It is recommended that you set the off-hand auto cast before the start of your hour. Further, you must have the mage off-hand weapon equipped to do so or it will not set it
 
 .
 **__Delaying Defensive Auto__**

--- a/miscellaneous-information/mechanics.txt
+++ b/miscellaneous-information/mechanics.txt
@@ -249,7 +249,7 @@ Normally throughout your Sunshine, Death's Swiftness, and Berserk, the 10% damag
 .
 .img:https://i.imgur.com/JlBezRH.mp4
 .
-        - The ability rotation being done is: <:zerk:535532854004678657> → <:barge:535532853916860437> → <:flankicon:841419289755385866> <:backhand:535532854302605333> → <:freedom:535541258240786434> → <:assault:535532855191928842> → (4-hit) <:destroy:535532879330148352> → (3-hit) <:gflurry:535532879283879977> → <:deci:535532879325822986> → <:gfury:535532879334080527> → <:flankicon:841419289755385866> <:backhand:535532854302605333>
+The ability rotation being done is: <:zerk:535532854004678657> → <:barge:535532853916860437> → <:flankicon:841419289755385866> <:backhand:535532854302605333> → <:freedom:535541258240786434> → <:assault:535532855191928842> → (4-hit) <:destroy:535532879330148352> → (3-hit) <:gflurry:535532879283879977> → <:deci:535532879325822986> → <:gfury:535532879334080527> → <:flankicon:841419289755385866> <:backhand:535532854302605333>
     • As can be seen, despite no ticks being lost, the <:backhand:535532854302605333> at the start of <:zerk:535532854004678657> dealt 3977 but the one on the final tick of <:zerk:535532854004678657> dealt 2185 as it was actually casted out of <:zerk:535532854004678657> due to this interaction.
     • The solution to it as follows:
         - Firtly, you can just not queue an ability that will be casted on the last tick of your ultimate

--- a/miscellaneous-information/mechanics.txt
+++ b/miscellaneous-information/mechanics.txt
@@ -246,10 +246,10 @@ Normally throughout your Sunshine, Death's Swiftness, and Berserk, the 10% damag
 ⬥ It is also important to take caution when using queuing, for if you queue something it delays the cast by 1 tick
     • This can cause issues when trying to cast an ability on the final tick of an ultimate to get the ultimate and aura damage modifiers stacking, as it makes your ability cast after the ultimate ends, rather than on the final tick.
     • This can be seen in the following video clip (courtesy of <@683763716394975294>):
-        - The ability rotation being done is: <:zerk:535532854004678657> → <:barge:535532853916860437> → <:flankicon:841419289755385866> <:backhand:535532854302605333> → <:freedom:535541258240786434> → <:assault:535532855191928842> → (4-hit) <:destroy:535532879330148352> → (3-hit) <:gflurry:535532879283879977> → <:deci:535532879325822986> → <:gfury:535532879334080527> → <:flankicon:841419289755385866> <:backhand:535532854302605333>
 .
 .img:https://i.imgur.com/JlBezRH.mp4
 .
+        - The ability rotation being done is: <:zerk:535532854004678657> → <:barge:535532853916860437> → <:flankicon:841419289755385866> <:backhand:535532854302605333> → <:freedom:535541258240786434> → <:assault:535532855191928842> → (4-hit) <:destroy:535532879330148352> → (3-hit) <:gflurry:535532879283879977> → <:deci:535532879325822986> → <:gfury:535532879334080527> → <:flankicon:841419289755385866> <:backhand:535532854302605333>
     • As can be seen, despite no ticks being lost, the <:backhand:535532854302605333> at the start of <:zerk:535532854004678657> dealt 3977 but the one on the final tick of <:zerk:535532854004678657> dealt 2185 as it was actually casted out of <:zerk:535532854004678657> due to this interaction.
     • The solution to it as follows:
         - Firtly, you can just not queue an ability that will be casted on the last tick of your ultimate

--- a/miscellaneous-information/mechanics.txt
+++ b/miscellaneous-information/mechanics.txt
@@ -243,6 +243,19 @@ Normally throughout your Sunshine, Death's Swiftness, and Berserk, the 10% damag
 .
 .img:https://i.imgur.com/0TxDCjz.png
 .
+⬥ It is also important to take caution when using queuing, for if you queue something it delays the cast by 1 tick
+    • This can cause issues when trying to cast an ability on the final tick of an ultimate to get the ultimate and aura damage modifiers stacking, as it makes your ability cast after the ultimate ends, rather than on the final tick.
+    • This can be seen in the following video clip (courtesy of <@683763716394975294>):
+        - The ability rotation being done is: <:zerk:535532854004678657> → <:barge:535532853916860437> → <:flankicon:841419289755385866> <:backhand:535532854302605333> → <:freedom:535541258240786434> → <:assault:535532855191928842> → (4-hit) <:destroy:535532879330148352> → (3-hit) <:gflurry:535532879283879977> → <:deci:535532879325822986> → <:gfury:535532879334080527> → <:flankicon:841419289755385866> <:backhand:535532854302605333>
+.
+.img:https://i.imgur.com/JlBezRH.mp4
+.
+    • As can be seen, despite no ticks being lost, the <:backhand:535532854302605333> at the start of <:zerk:535532854004678657> dealt 3977 but the one on the final tick of <:zerk:535532854004678657> dealt 2185 as it was actually casted out of <:zerk:535532854004678657> due to this interaction.
+    • The solution to it as follows:
+        - Firtly, you can just not queue an ability that will be casted on the last tick of your ultimate
+        - Secondly, you can turn queuing off
+
+.
 > **__Grimoire and Scrimshaw Switching__**
 .tag:grimshaw
 **__Obtaining both pocket slot's benefits__**

--- a/telos/telos-beginner.txt
+++ b/telos/telos-beginner.txt
@@ -449,7 +449,7 @@ Phase 5 uses the same arena as P4. You drop down on the south side (close to whe
 
 ⬥ You can likely camp Soul Split <:soulsplit:615613924506599497> for much of this phase, though Deflect Melee <:DeflectMelee:544195488447201300> when minions are attacking you is recommended.
 
-⬥ Sunshine <:Sunshine:583430011948630016> / Death's swiftness Sunshine <:Sunshine:583430011948630016> as soon as you get in green beam and focus on stunning Telos.
+⬥ Sunshine <:Sunshine:583430011948630016> / Death's Swiftness <:DeathsSwift:513190158812839936> as soon as you get in green beam and focus on stunning Telos.
 
 .
 ⬥ When minions have grouped up:

--- a/upgrading-info/permanent-unlocks.txt
+++ b/upgrading-info/permanent-unlocks.txt
@@ -97,7 +97,7 @@
     • -8 to -12 enemy drain modifier (for armour)
     • -9% to -15% enemy damage
     • Priority: `High`
-    • Bigger upgrade than most T92 weapons, should be prioritized after basic gear is obtained (see <#689236598847701075>)
+    • Bigger upgrade than t92s without a special attack or passive, as well as the Staff of Sliske <:Sos:626466320132734976>, should be prioritized after basic gear is obtained (see <#689236598847701075>)
 
 .
 > **__Archaeology Relics__**
@@ -280,6 +280,9 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • Unlocks ability to have NPCs decant flasks for you
     • Priority: `Medium`
 
+⬥ **City of Senntisten**
+    • Unlocks the Smoke Cloud, Animate Dead, Exsanguinate, and Incite Fear spells
+    • Priority: `High`
 .
 **__Quests for Dominion Mines__** <:dommine:662249620579155968>
 Note: Only the last quests in a quest line are listed, rather than listing all prerequisites.

--- a/upgrading-info/permanent-unlocks.txt
+++ b/upgrading-info/permanent-unlocks.txt
@@ -105,13 +105,13 @@
 The general layout for most pvm scenarios is: Fury of the Small, Berserker's Fury, and Death Ward.
 Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_Power_Setup>
 
+.
 **__General PvM Relics__**
 ⬥ **Font of Life** <:fontoflife:698225967679930408>
     • Increases maximum health by 500
     • Obtained by completing the Archaeology tutorial
     • Priority: `Low, replace with Death Ward when you unlock 650 monolith power`
 
-.
 ⬥ **Berserker's Fury** <:berserkersfury:697808774106185768>
     • Deal up to +5.5% damage the lower your current life points are below max
         - Averages to around 2-3% dpm increase
@@ -128,7 +128,6 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • Note: If Armadyl isn't at his tower, check your *__Sliske's Endgame__* quest log. If it is not complete, you need to redo the last boss fight. Once the quest is completed Armadyl will be back on top of his tower.
     • Priority: `Medium if you have 650 monolith power unlocked, low otherwise`
 
-.
 ⬥ **Fury of the Small** <:furyofthesmall:697808773917573233>
     • All basic abilities generate 1% more adrenaline
     • Unlocked by solving *__Out of the Cruicible__* mystery.
@@ -142,7 +141,6 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • 105 Archaeology (boostable)
     • Priority: `High if ranging, low otherwise (replaces Fury of the Small in some Ranged encounters)`
 
-.
 ⬥ **Conservation of Energy** <:conservationofenergy:697808773711921195>
     • After using an ultimate ability, you will regain 10% adrenaline
     • Chuluu stone combined with invention components, requires 108 invention
@@ -172,6 +170,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
 ⬥ Increases enchanted bolt proc chance by a flat 2%
     • Priority: `High`
 
+.
 ⬥ **Easy Tirannwn Task Set**
     • Access to quiver (each tier gives a higher prayer bonus)
     • Priority: `High if using ascendri bolts, low otherwise`
@@ -204,6 +203,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • *__The Temple at Senntisten__* and *__Desert Treasure__* quests are prerequisites for *__The Light Within.__*
     • Priority: `High`
 
+.
 ⬥ **The Digsite**
     • Awards the Codex Ultimatus, which unlocks the smoke/shadow/blood tendrils <:Smoke_Tendrils:536257336130404372> <:shadowtend:642713547142332416> <:BloodTend:513190158431158274> and ice asylum <:IceAsylum:553050196817215491> abilities
     • Priority: `High for Melee/Ranged, low for Magic`
@@ -217,6 +217,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • Must do all 3 challenges post-quest for Asylum surgeon's ring <:asr:513190158472839208>
     • Priority: `Low`
 
+.
 ⬥ **Icthlarin's Little Helper**
     • Access to Sophanem, its slayer dungeon, and Magister <:magister:643788569579618304>
         -*__Jack of Spades__* quest gives access to Menaphos and its reputation system
@@ -244,6 +245,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • Unlocks dragonrider amulet <:drider:656785090994503700> and celestial dragons
     • Priority: `Medium`
 
+.
 ⬥ **Song from the Depths**
     • Reduced damage at Queen Black Dragon <:qbd:513212948194394113>
     • Access to QBD as reaper assignment
@@ -257,6 +259,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
     • Unlocks the Fight Kiln
     • Priority: `Medium`
 
+.
 ⬥ **Ritual of the Mahjarrat**
     • Unlock ability to make dragonbane arrows/bolts
     • Unlock Stone of Jas buff for GWD1
@@ -271,6 +274,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
         -The *__Lair of Tarn Razorlor__* miniquest gives access to Salve Amulet (e) <:salveamulet:797899945730244648>
     • Priority: `Medium`
 
+.
 ⬥ **Let Them Eat Pie**
     • Access to Expensive Spices <:spices:662038182807732255>
     • Priority: `Low`
@@ -283,6 +287,7 @@ Further examples may be seen here: <https://runescape.wiki/w/Optimal_PvM_Relic_P
 ⬥ **City of Senntisten**
     • Unlocks the Smoke Cloud, Animate Dead, Exsanguinate, and Incite Fear spells
     • Priority: `High`
+
 .
 **__Quests for Dominion Mines__** <:dommine:662249620579155968>
 Note: Only the last quests in a quest line are listed, rather than listing all prerequisites.
@@ -295,12 +300,14 @@ Note: Only the last quests in a quest line are listed, rather than listing all p
     • Dagannoth Sentinels + Both Mothers
     • The Inadequacy, Everlasting + Illusive, Untouchable
     • Koschei + Draugen
+.
 ⬥ **The Curse of Arrav**
     • Arrav
 ⬥ **Demon Slayer**
     • Delrith
 ⬥ **Dragon Slayer**
     • Melzar + Elvarg
+.
 ⬥ **Lair of Tarn Razorlor**
     • Tarn
     • Treus
@@ -308,6 +315,7 @@ Note: Only the last quests in a quest line are listed, rather than listing all p
     • Tumeken
 ⬥ **Mountain Daughter**
     • Kendal
+.
 ⬥ **Nomad's Requiem**
     • Nomad
 ⬥ **Recipe for Disaster**
@@ -333,6 +341,7 @@ Note: Only the last quests in a quest line are listed, rather than listing all p
     • Permanently increases duration of bonfire health boost duration by 25%
     • Priority: `Medium`
 
+.
 ⬥ **Instance Cost**
     • Reduces instance costs by 25%
     • Priority: `Low`
@@ -356,7 +365,6 @@ Note: Only the last quests in a quest line are listed, rather than listing all p
     • A 2% (at tier 1) or 3% (at tier 2) damage increase against all spiders as well as Araxxor/Araxxi
     • Priority: `High if you do Araxxi, Low otherwise`
 
-.
 ⬥ **King of Beasts Perk** <:bagrada:690136116992671875>
     • A 5% (at tier 1) or 10% (at tier 2) chance to conserve a bomb when thrown
     • Priority: `Medium, can save some money when other perks are not useful`
@@ -366,7 +374,6 @@ Note: Only the last quests in a quest line are listed, rather than listing all p
     • Increases the critical hit chance of Meteor Strike <:meteorstrike:535532879359377439> by 20% (at tier 1) or 40% (at tier 2)
     • Priority: `Medium`
 
-.
 ⬥ **Armoured Hide Perk** <:malletops:690136117374484508>
     • Increases the duration of Barricade <:cade:535541306353778689> by 1.8 seconds (at tier 1) or 3.6 seconds (at tier 2)
     • Priority: `High at any place you need to Barricade`
@@ -389,6 +396,7 @@ The Max and Completionist capes can fit 3 perks, and the Combatant's cape can fi
     • Scales with maximum HP
     • Priority: `High`
 
+.
 ⬥ **Ranged** <:Ranged:689504724403486920>
     • Ammo proc chance is increased by 20% of the base chance.
     • Priority: `High if ranging, otherwise Low`
@@ -401,6 +409,7 @@ The Max and Completionist capes can fit 3 perks, and the Combatant's cape can fi
 .
 > **__Miscellaneous Upgrades__**
 .tag:misc
+**__General Upgrades__**
 ⬥ **Reaper Crew** <:achiev:641342351532621824>
     • For killing each boss once you unlock the following benefits:
         - +2 Prayer bonus
@@ -409,18 +418,6 @@ The Max and Completionist capes can fit 3 perks, and the Combatant's cape can fi
         - +12 Melee/Mage/Ranged Damage bonus
     • Priority: `High`
 
-.
-⬥ **Raids Shop Ring Imbues** <:teci:641332337451204608>
-    • Applies mainly for RoD <:RoD:513190159462825984> and Asr <:asr:513190158472839208>, but the general idea is the same for all imbueable rings
-    • Gives a ~+2 permanent stat buff to the ring's damage bonuses
-    • Priority: `Low`
-
-.
-⬥ **Anachronia Skillcape Stand**
-    • Adds an additional skillcape slot at the Anachronia player lodge
-    • Priority: `Medium`
-
-.
 ⬥ **Anachronia Slayer Helmet Stand**
     • Placing a slayer helmet grants slayer helmet bonuses everywhere without needing to wear it
     • Priority: `High for slayer, low otherwise`
@@ -431,22 +428,31 @@ The Max and Completionist capes can fit 3 perks, and the Combatant's cape can fi
     • Permanently reduces the cost of Summoning familiar special attack costs by 20%
     • Priority: `High`
 
-.
 ⬥ **Permanent Access to Nex Bank**
     • Players can speak to Ashuelot Reis in the Nex Bank with a set of ancient ceremonial robes, a frozen key and 10,000,000 coins <:coins:698816156961603654> to allow for permanent free access to Nex's lobby.
     • Priority: `High if doing a lot of Nex/AoD, Low otherwise`
 
 .
+**__Customizable Upgrades__**
 ⬥ **Increased Monolith Energy**
     • After completing the Mysterious City mystery in the Orthen digsite, you will receive an extra 150 monolith energy, totalling to 650.
     • Level 120 arch, boostable from 117
     • Priority: `Medium, 500 monolith energy is good enough for most activities`
+
+⬥ **Anachronia Skillcape Stand**
+    • Adds an additional skillcape slot at the Anachronia player lodge
+    • Priority: `Medium`
 
 .
 ⬥ **Dreadnips** <:nip:537336877900890135>
     • Dominion Tower reward for achieving 450 boss kills and spectating another player's match.
     • Dreadnips can deal upwards of 8k average dpm and are usable against most monsters.
     • Priority: `Medium`
+
+⬥ **Raids Shop Ring Imbues** <:teci:641332337451204608>
+    • Applies mainly for RoD <:RoD:513190159462825984> and Asr <:asr:513190158472839208>, but the general idea is the same for all imbueable rings
+    • Gives a ~+2 permanent stat buff to the ring's damage bonuses
+    • Priority: `Low`
 
 .
 > **__Table of Contents__**


### PR DESCRIPTION
• #auto-attack: clarified need OH autocast, along with a magic offhand, to cast an offhand spell auto with not magic
• #permanent-unlocks: made it less ambiguous which t92 weapons t99 prayer is better than, also added new quest to the quest list
• #dpm-advice-mage: removed references of Detonate being a channeled ability
• #mechanics: made note of queuing interactions with relation to final tick of ultimates
• #telos-beginner: fixed broken deaths swift emoji
• #vindicta: in afk section made eof say prot prayer passinve instead of ss passive, as the method states reliance on camping prot prayers not ss