### PR TITLE
Various channel changes/fixes

### DIFF
--- a/dpm-advice/dpm-advice-faq.txt
+++ b/dpm-advice/dpm-advice-faq.txt
@@ -27,7 +27,7 @@ As an example, in a 5 minute gem you will use up to 12 Asphyx's <:asphyx:5355338
 **__How to Fix__**
 <@145413546409197569>'s video guide on correct canceling timing:
 .
-https://www.youtube.com/watch?v=unCtj7IosVA>
+https://www.youtube.com/watch?v=unCtj7IosVA
 .
 *Note: The buff bar timers shown are outdated in the video, use !cancelling in <#534563158304620564> instead to get up-to-date timers.*
 

--- a/dpm-advice/dpm-advice-faq.txt
+++ b/dpm-advice/dpm-advice-faq.txt
@@ -25,9 +25,11 @@ As an example, in a 5 minute gem you will use up to 12 Asphyx's <:asphyx:5355338
 
 .
 **__How to Fix__**
-<@145413546409197569>'s video guide on correct canceling timing: <https://www.youtube.com/watch?v=unCtj7IosVA>
-
-The buff bar timers shown are outdated in the video, use !cancelling in #bot-commands instead to get up-to-date timers.
+<@145413546409197569>'s video guide on correct canceling timing:
+.
+https://www.youtube.com/watch?v=unCtj7IosVA>
+.
+*Note: The buff bar timers shown are outdated in the video, use !cancelling in <#534563158304620564> instead to get up-to-date timers.*
 
 .
 > __**Threshold Prioritisation During Your Ultimate**__

--- a/dpm-advice/dpm-advice-mage.txt
+++ b/dpm-advice/dpm-advice-mage.txt
@@ -199,7 +199,7 @@ In RuneScape PvM, the meta at the time of writing is about pushing out as much d
     • Every ability cast applies a stack:
         - This caps at 12 stacks, after which it will no longer consume runes on ability casts
         - Stacks are lost every 20 seconds, refreshed when attemping to apply another stack
-        - Each stack increases basic ability damage by +1%
+        - Each stack increases basic ability damage by +1% (excluding <:comb:535533833098100745> and <:corruptblast:513190159194259467>)
     • Wrack and Ruin <:wrackandruin:856662355912032256>:
         - At 12 stacks <:wrack:856662355952795658> becomes <:wrackandruin:856662355912032256>
         - It deals 60-300% ability damage (120-360% on stun/bound)
@@ -210,9 +210,9 @@ In RuneScape PvM, the meta at the time of writing is about pushing out as much d
     • Cooldown: Based on Weapon Speed
         - Fastest (Wand): 4t (2.4s)
         - Average (Staff): 6t (3.6s)
-    • Increases damage dealt with critical hits by 15%
-    • Increases critical hit damage cap by 12%
-        - This also stacks with Grimoire <:grim:568262896375824385> to make the hitcap 16.8k
+    • Increases damage dealt with critical hits by 15% for Magic, 6% otherwise
+    • Increases critical hit damage cap by 12% for Magic, 4.8% otherwise
+        - This also stacks with Grimoire <:grim:568262896375824385> to make the hitcap 16.8k for Magic, 15.72k otherwise
     • Lasts 120 seconds
 
 .

--- a/dpm-advice/dpm-advice-melee.txt
+++ b/dpm-advice/dpm-advice-melee.txt
@@ -403,7 +403,7 @@ Berserk <:Berserk:513190158468907012> + Adrenaline Potion <:replenpot:6413374704
         - Another niche consideration is when under the effects of Berserk <:zerk:535532854004678657> (and <:grim:568262896375824385>), there is almost no damage difference between <:gfury:535532879334080527> → <:assault:535532853979512842> and 188% → <:assault:535532853979512842>.
     • Without the active effects of <:grim:568262896375824385>, <:gfury:535532879334080527> is basically always weaker than a 188% ability.
         - Despite this, if you are put into a position where you have no 188% abilities available and need to use <:gfury:535532879334080527>, you should consider following it up with a >188% ability to still maximise your damage.
-
+*Note: A sheet comparing <:gfury:535532879334080527> to <:deci:535532879325822986>/<:cleave:535532878616985610>/<:sever:535532879577612298> before various abilities can be found here: <https://docs.google.com/spreadsheets/d/1beHYkyPKV-tj8eHlbRDQTRX9GkdFBKhBr89B8fKyuXI/edit#gid=1063393167>*
 .
 **__Greater Flurry__** <:gflurry:535532879283879977>
 ⬥ Greater Flurry can be unlocked through consuming a Greater Flurry Ability Codex.

--- a/dpm-advice/dpm-advice-melee.txt
+++ b/dpm-advice/dpm-advice-melee.txt
@@ -403,7 +403,8 @@ Berserk <:Berserk:513190158468907012> + Adrenaline Potion <:replenpot:6413374704
         - Another niche consideration is when under the effects of Berserk <:zerk:535532854004678657> (and <:grim:568262896375824385>), there is almost no damage difference between <:gfury:535532879334080527> → <:assault:535532853979512842> and 188% → <:assault:535532853979512842>.
     • Without the active effects of <:grim:568262896375824385>, <:gfury:535532879334080527> is basically always weaker than a 188% ability.
         - Despite this, if you are put into a position where you have no 188% abilities available and need to use <:gfury:535532879334080527>, you should consider following it up with a >188% ability to still maximise your damage.
-*Note: A sheet comparing <:gfury:535532879334080527> to <:deci:535532879325822986>/<:cleave:535532878616985610>/<:sever:535532879577612298> before various abilities can be found here: <https://docs.google.com/spreadsheets/d/1beHYkyPKV-tj8eHlbRDQTRX9GkdFBKhBr89B8fKyuXI/edit#gid=1063393167>*
+*Note: A sheet comparing <:gfury:535532879334080527> to <:deci:535532879325822986>/<:cleave:535532878616985610>/<:sever:535532879577612298> before various abilities can be found here:
+<https://docs.google.com/spreadsheets/d/1beHYkyPKV-tj8eHlbRDQTRX9GkdFBKhBr89B8fKyuXI/edit#gid=1063393167>*
 .
 **__Greater Flurry__** <:gflurry:535532879283879977>
 ⬥ Greater Flurry can be unlocked through consuming a Greater Flurry Ability Codex.

--- a/getting-started/perks.txt
+++ b/getting-started/perks.txt
@@ -234,6 +234,7 @@ If you wish to test your own perk combinations you can use the wiki calc
 .tag:guide
 The fastest and most efficient way to quickly level up your items (Courtesy of <@231624498435194880>):
 <https://www.youtube.com/watch?v=oy0IZCZWTn0>
+*Note: Use 8 <:serencomp:583435429877907456> 1 <:piouscomp:583434604363644929> `(1/1.08 at 120 invention)` for Enlightened 4, instead of 8 <:serencomp:583435429877907456> as mentioned in the video*
 
 .
 > __**Table of Contents**__

--- a/miscellaneous-information/pvm-spreadsheets.txt
+++ b/miscellaneous-information/pvm-spreadsheets.txt
@@ -87,5 +87,5 @@ Disc: https://discord.gg/deqFqtXgNp
 <https://docs.google.com/spreadsheets/d/1mJ1wB-JhmWRnEpI4iRVnyRkP93Dk9lTxefr3bGd3Lnw/>
 
 .
-**__Greater Fury vs 188__**
+**__Greater Fury vs 188 Comparison Before an Ability__**
 <https://docs.google.com/spreadsheets/d/1beHYkyPKV-tj8eHlbRDQTRX9GkdFBKhBr89B8fKyuXI/edit#gid=1063393167>

--- a/miscellaneous-information/pvm-spreadsheets.txt
+++ b/miscellaneous-information/pvm-spreadsheets.txt
@@ -85,3 +85,7 @@ Disc: https://discord.gg/deqFqtXgNp
 .
 **__Onslaught Calc__**
 <https://docs.google.com/spreadsheets/d/1mJ1wB-JhmWRnEpI4iRVnyRkP93Dk9lTxefr3bGd3Lnw/>
+
+.
+**__Greater Fury vs 188__**
+<https://docs.google.com/spreadsheets/d/1beHYkyPKV-tj8eHlbRDQTRX9GkdFBKhBr89B8fKyuXI/edit#gid=1063393167>


### PR DESCRIPTION
• #pvm-spreadsheets: added gfury vs 188 sheet
• #dpm-advice-melee: added gfury vs 188 sheet
• #dpm-advice-mage: clarified what exsang doesnt boost, added the non-magic increases to smoke cloud
• #dpm-advice-faq: unembedded lucas cancelling video, converted the buff bar being outdated line to the pvme note syntax, fixed the broken bot-commands channel link in the section
• #perks: added a note saying to use 8 seren 1 pious at 120 for enlightened 4 after the item levelling video, unlike the 8 seren setup shown