### PR TITLE
Solak Channel Fixes

### DIFF
--- a/solak/solak-magic-brid.txt
+++ b/solak/solak-magic-brid.txt
@@ -36,7 +36,7 @@ __**General Notes**__
 .img:https://i.imgur.com/YSB6lot.png
 .
 **__DPS__**
-⬥ <:caloriebomb:656790558177755169> **Calorie Bomb**
+⬥ <:bomb:656790558177755169> **Calorie Bomb**
 ⬥ <:eofred:780401412839833601> **Essence of Finality** - <:dragonclaw:779048041088024606> Dragon Claws
 ⬥ <:redpouch:690848915020447745> **Rune Pouch** <:Lawrune:536252661406760970> <:Cosmicrune:536252659615924258> <:Firerune:536252659850674186>
 ⬥ <:bluepouch:656786565527502858> **Rune Pouch** <:Bloodrune:536252658970001409> <:Astralrune:536252658961481769> <:Bodyrune:536252659301089280>
@@ -130,7 +130,7 @@ This phase is split into two sections, the first is dealing with Eruptions and t
 
 ⬥ Once eruptions are killed, it is assumed that cleansing with Merethiel is done once, before going up to clear the blight storm for the first time.
 
-⬥ Solak does not have enough HP to deplete the blight bar naturally before he reaches his HP cap, therefore the use of a <calorie bomb> is required. This is best used during your <:Berserk:513190158468907012>, and as the bomb drains 10% adrenaline from the user, best used after Hurricane <:cane:535532878969438210>
+⬥ Solak does not have enough HP to deplete the blight bar naturally before he reaches his HP cap, therefore the use of a <:caloriebomb:656790558177755169> is required - it is worth noting that the Eat Food ability can use <:caloriebomb:656790558177755169>. This is best used during your <:Berserk:513190158468907012>, and as the bomb drains 10% adrenaline from the user, best used after Hurricane <:cane:535532878969438210>
 
 .
 **__South Eruptions__**

--- a/solak/solak-magic-brid.txt
+++ b/solak/solak-magic-brid.txt
@@ -23,6 +23,10 @@ __**General Notes**__
 
 ⬥ These presets are completely filled, requiring the player to drop a Spiritual <:spiritualprayer:651079281882955787> at the start of the fight to pick up later when the spot is free, after Dominion mines <:dommine:662249620579155968> are placed or another <:spiritualprayer:651079281882955787> is drank. If not comfortable with this, the player can opt to bring a <:weppoison:689525476158472288> with them, to free up a space.
 
+⬥ It is assumed Borrowed Power <:borrowedpower:657248051190300682> is set to Smoke Cloud <:smokecloud:856635090641879050>
+
+⬥ The Malevolent Helmet <:malevhelm:643847008066469908> is for bigger Vengeances <:Veng:543478434953822208>
+
 .
 **__Base__**
 ⬥ <:eofpurple:780401412936040478> **Essence of Finality** - <:gstaff:513203008608141314> Guthix Staff

--- a/solak/solak-mechanics.txt
+++ b/solak/solak-mechanics.txt
@@ -411,13 +411,14 @@ Hybriding assumes the player starts from a mage or range setup, adding in melee 
 ⬥ Melee Helmet
 ⬥ EoF Gstaff
 ⬥ Melee Boots
+⬥ Borrowed Power Smoke Cloud <:borrowedpower:657248051190300682> (<:smokecloud:856635090641879050>)
 
 The presets below give a rough idea of how presets adapt from a base Magic setup, to a learner Hybrid setup, to an advanced Hybrid Setup. Some items are more or less useful depending on the role, Base vs DPS:
 .
 Mage Camp
 .img:https://i.imgur.com/DCgmYwq.png
 Learner Brid
-.img:https://i.imgur.com/Zl4zik3.png
+.img:https://i.imgur.com/wxObbrF.png
 Full Mage Brid
 .img:https://i.imgur.com/mllVTJS.png
 .
@@ -431,6 +432,7 @@ Full Mage Brid
 ⬥ EoF ECB
 ⬥ EoF SGB
 ⬥ Melee Boots
+⬥ Borrowed Power Smoke Cloud <:borrowedpower:657248051190300682> (<:smokecloud:856635090641879050>)
 
 The presets below give a rough idea of how presets adapt from a base Ranged setup, to a learner Hybrid setup, to an advanced Hybrid Setup. Some items are more or less useful depending on the role, Base vs DPS:
 .
@@ -440,7 +442,7 @@ The presets below give a rough idea of how presets adapt from a base Ranged setu
 .
 **__Learner Brid__**
 .
-.img:https://imgur.com/KRYLNPB.png
+.img:https://i.imgur.com/APsB3lo.png
 .
 **__Full Range Brid__**
 .

--- a/solak/solak-range-brid.txt
+++ b/solak/solak-range-brid.txt
@@ -29,38 +29,35 @@ __**General Notes**__
 
 ⬥ Off-style bodies are worn for the purpose of the Mobile <:mob:689501908628799488> perk.
 
+⬥ It is assumed Borrowed Power <:borrowedpower:657248051190300682> is set to Smoke Cloud <:smokecloud:856635090641879050>
+
 .
 **__Base__**
 ⬥ <:eofblue:780401412906680330> **Essence of Finality** - <:sgb:626466665848242186> SGB
 ⬥ <:eofgreen:780401412727242773> **Essence of Finality** - <:dbow:643848618553507843> Dbow
 ⬥ <:eofpink:780401412865523722> **Essence of Finality** - <:ecb:615618531937222657> ECB
-⬥ <:redpouch:690848915020447745> **Rune Pouch** <:Lawrune:536252661406760970> <:Cosmicrune:536252659615924258> <:Firerune:536252659850674186>
 ⬥ <:bluepouch:656786565527502858> **Rune Pouch** <:Bloodrune:536252658970001409> <:Astralrune:536252658961481769> <:Bodyrune:536252659301089280>
-⬥ <:yellowpouch:690848914949144616> **Rune Pouch** <:Dustrune:536252659670188042> <:Soulrune:536252660333019136> <:Chaosrune:536252659422855188>
-(Runes for <:smokecloud:856635090641879050>, <:disrupt:535614336207552523>, <:SBSLunars:565726489467682816>)
+(Runes for <:borrowedpower:657248051190300682> (<:smokecloud:856635090641879050>), <:disrupt:535614336207552523>)
 .
-.img:https://imgur.com/CtObA5u.png
+.img:https://i.imgur.com/I4jt91U.png
 .
-**__DPS__**
+**__DPS (No Dummy)__**
 ⬥ <:eofblue:780401412906680330> **Essence of Finality** - <:sgb:626466665848242186> SGB
 ⬥ <:eofgreen:780401412727242773> **Essence of Finality** - <:dbow:643848618553507843> Dbow
 ⬥ <:eofpink:780401412865523722> **Essence of Finality** - <:ecb:615618531937222657> ECB
-⬥ <:redpouch:690848915020447745> **Rune Pouch** <:Lawrune:536252661406760970> <:Cosmicrune:536252659615924258> <:Firerune:536252659850674186>
 ⬥ <:bluepouch:656786565527502858> **Rune Pouch** <:Bloodrune:536252658970001409> <:Astralrune:536252658961481769> <:Bodyrune:536252659301089280>
-⬥ <:yellowpouch:690848914949144616> **Rune Pouch** <:Dustrune:536252659670188042> <:Soulrune:536252660333019136> <:Chaosrune:536252659422855188>
-(Runes for <:smokecloud:856635090641879050>, <:disrupt:535614336207552523>, <:SBSLunars:565726489467682816>)
+(Runes for <:borrowedpower:657248051190300682> (<:smokecloud:856635090641879050>), <:disrupt:535614336207552523>)
 .
-.img:https://imgur.com/FWdu49c.png
+.img:https://i.imgur.com/hHP7Yrh.png
 .
 **__Advanced DPS__**
+⬥ <:eofblue:780401412906680330> **Essence of Finality** - <:sgb:626466665848242186> SGB
 ⬥ <:eofgreen:780401412727242773> **Essence of Finality** - <:dbow:643848618553507843> Dbow
 ⬥ <:eofpink:780401412865523722> **Essence of Finality** - <:ecb:615618531937222657> ECB
-⬥ <:redpouch:690848915020447745> **Rune Pouch** <:Lawrune:536252661406760970> <:Cosmicrune:536252659615924258> <:Firerune:536252659850674186>
 ⬥ <:bluepouch:656786565527502858> **Rune Pouch** <:Bloodrune:536252658970001409> <:Astralrune:536252658961481769> <:Bodyrune:536252659301089280>
-⬥ <:yellowpouch:690848914949144616> **Rune Pouch** <:Dustrune:536252659670188042> <:Soulrune:536252660333019136> <:Chaosrune:536252659422855188>
-(Runes for <:smokecloud:856635090641879050>, <:disrupt:535614336207552523>, <:SBSLunars:565726489467682816>)
+(Runes for <:borrowedpower:657248051190300682> (<:smokecloud:856635090641879050>), <:disrupt:535614336207552523>)
 .
-.img:https://imgur.com/ixsk9o8.png
+.img:https://i.imgur.com/UzAaYya.png
 .
 > __**Phase 1**__
 .tag:p1

--- a/solak/solak-range.txt
+++ b/solak/solak-range.txt
@@ -17,6 +17,7 @@ __**General Notes**__
 
 ⬥ It is easier to apply the Smoke Cloud <:smokecloud:856635090641879050> debuff with Ranged, at the start of Death's Swiftness <:DeathsSwift:513190158812839936> with the use of Ingenuity of the Humans <:ingen:641339234111848463>. Solak, Core, and Erethdor should all be debuffed, and co-ordinate between team members as to who is applying it.
 
+⬥ It is assumed Borrowed Power <:borrowedpower:657248051190300682> is set to Smoke Cloud <:smokecloud:856635090641879050>
 .
 > __**Presets**__
 .tag:presets


### PR DESCRIPTION
• #solak-magic-brid: broke a broken calorie bomb emoji, mentioned Eat Food ability can use calorie bombs
• #solak-mechanics: several preset fixes
Learner Mage Brid: Changed from 4 to 3 pouch setup (orange red blue), added t92 spear
Learner Range Brid: Changed from 3 to 2 pouch setup (BP smoke setup), removed an extra salve, added t92 spear and super brew
• #solak-range-brid: several preset fixes
General Notes: Mentioned BP Smoke is assumed
Base: Removed 2 pouches (kept blue), added 2 spirituals
Advanced DPS: Removed 2 pouches (kept blue), added spiritual and sgb eof
DPS: Renamed to DPS (No Dummy), Removed Chins, and 2 pouches (kept blue), added 2 spirituals and melee boots
• #solak-range:
General Notes: Mentioned BP Smoke is assumed
• #solak-magic-brid:
General Notes: Mentioned BP Smoke is assumed, mention malev helm is for bigger venges