### PR TITLE
Various channel fixes

### DIFF
--- a/dpm-advice/dpm-advice-mage.txt
+++ b/dpm-advice/dpm-advice-mage.txt
@@ -313,7 +313,7 @@ In RuneScape PvM, the meta at the time of writing is about pushing out as much d
         - Becomes a 188% basic
     • Not affected by Impatient <:imp4:712073088204013640>
     • Affected by Energizing:
-        - Gain (Energizing Rank \* 0.6) more
+        - Gain (Energizing Rank \* 0.6) more adrenaline
 
 .
 **__Thresholds__**
@@ -406,7 +406,7 @@ In RuneScape PvM, the meta at the time of writing is about pushing out as much d
 **__Hit Timings__**
 Refer to this table for hit timings of each ability
 .
-.img:https://i.imgur.com/vSfkUZg.png
+.img:https://i.imgur.com/pKnij2q.png
 .
 *Notes:*
 ⬥ *All distances mentioned assume Melee Distance (MD) is tile 1, so "8" = (MD + 7) tiles*
@@ -793,6 +793,7 @@ https://youtu.be/HmZR1BBwsK0
         - Concentration Blast <:conc:535533833106489365>
         - Wrack <:wrack:856662355952795658>
         - Auto Attack (such as <:AirSurge:543465115870035999>)
+*Note: <:wrack:856662355952795658> is being used for practice solely due to its short cooldown, in actual PvM you should almost never be using this ability*
 
 .
 ⬥ **Step 1**:

--- a/elite-dungeons/dragonkin-laboratory-melee.txt
+++ b/elite-dungeons/dragonkin-laboratory-melee.txt
@@ -15,6 +15,7 @@ Each solo run of ED2 is worth <:coins:698816156961603654> $data_pvme:Bosses!E546
 ⬥ The rotations listed for the bosses are for an advanced setup, lower tiered set-ups will require improvisation.
 ⬥ It's recommended to set your anti-spam delay for your Double Surge <:surge:535533810004262912> to 1 via the Lectern at Anachronia.
 ⬥ You can Surge <:surge:535533810004262912> Bladed Dive <:bd:535532854281764884> a tick before each gate unlocks to save a tick on every entry.
+⬥ The Corbicula Rex <:corbicula:690136117273821280> perk (112 Farming) in ROoT is extremely helpful in this dungeon, as Meteor Strike <:meteorstrike:535532879359377439> is frequently used here.
 
 .
 > __**Presets**__

--- a/elite-dungeons/the-shadow-reef-melee.txt
+++ b/elite-dungeons/the-shadow-reef-melee.txt
@@ -16,6 +16,7 @@ Each solo run of ED3 is <:coins:698816156961603654> worth $data_pvme:Bosses!E568
 ⬥ It's recommended to set your anti-spam delay for your Double Surge <:surge:535533810004262912> to 1 via the Lectern at Anachronia.
 ⬥ Consider downgrading your graphics to Minimum with Medium+ draw distance for the Dungeon, as it is poorly optimized and prone to frame drops.
 ⬥ You can Surge <:surge:535533810004262912> or Bladed Dive <:bd:535532854281764884> a tick before each gate unlocks to save a tick on every entry.
+⬥ The Corbicula Rex <:corbicula:690136117273821280> perk (112 Farming) in ROoT is extremely helpful in this dungeon, as Meteor Strike <:meteorstrike:535532879359377439> is frequently used here.
 
 .
 > __**Presets**__

--- a/getting-started/bossing-path.txt
+++ b/getting-started/bossing-path.txt
@@ -99,7 +99,7 @@ Elite Dungeon Three: Shadow Reef
     • Spacing and movement must be perfect
     • Teaches usage of many Magic spells <:icebarrage:537340400185245701> <:SBS:543875425055670275> <:disrupt:535614336207552523>
         - Magic is generally advised for Telos learners, since it is the safest style and has the lowest entry gear requirements.
-⬥ <#534571389487808534>
+⬥ <#854168962140340224>
 
 .
 > **__Other Good PvM Encounters__**

--- a/mid-tier-pvm/vindicta.txt
+++ b/mid-tier-pvm/vindicta.txt
@@ -112,7 +112,7 @@ This is identical to the lines placed during phase 1 and can be dealt with the s
 
 .
 **__Kill 1: (100% adrenaline required)__**
-<:zerk:535532854004678657> → (tc) <:gbarge:535532879250456578> → <:cleave:535532878616985610> → <:deci:535532879325822986> → <:limitless:641339233638023179> + <:destroy:535532879330148352> → <:gflurry:535532879283879977> → <:cleave:535532878616985610> → (fastest) <:assault:535532853979512842> → <:deci:535532879325822986> → (5taa) <:cleave:535532878616985610> → <:dismember:535532879376023572> → <:freedom:535541258240786434> → Improvise (Finish kill on 82%+ adrenaline, if you triple Imp Proc or Asr/Relentless 3hit flurry under sigil and dont 5taa later)
+<:zerk:535532854004678657> → (tc) <:gbarge:535532879250456578> → <:cleave:535532878616985610> → <:deci:535532879325822986> → <:limitless:641339233638023179> + <:destroy:535532879330148352> → (2-hit) <:gflurry:535532879283879977> → <:cleave:535532878616985610> → (fastest) <:assault:535532853979512842> → <:deci:535532879325822986> → (5taa) <:cleave:535532878616985610> → <:dismember:535532879376023572> → <:freedom:535541258240786434> → Improvise (Finish kill on 82%+ adrenaline, if you triple Imp Proc or Asr/Relentless 3hit flurry under sigil and dont 5taa later)
 
 .
 **__Kill 2: (82% adrenaline required)__**

--- a/miscellaneous-information/boss-revenue.txt
+++ b/miscellaneous-information/boss-revenue.txt
@@ -213,8 +213,6 @@ Solo ($data_pvme:Bosses!B120$ kph) <:coins:698816156961603654> $data_pvme:Bosses
 Commons <:coins:698816156961603654> $data_pvme:Bosses!E606$
 Total <:coins:698816156961603654> $data_pvme:Bosses!B606$
 
-*Note: Raksha drop rates are estimated to be 1/200 for boots and 1/500 for codex/spikes; however, they are not officially known.*
-
 .
 **__Gp/Hour__**
 Solo ($data_pvme:Bosses!B609$ kph) <:coins:698816156961603654> $data_pvme:Bosses!C609$

--- a/upgrading-info/consumables.txt
+++ b/upgrading-info/consumables.txt
@@ -77,9 +77,8 @@ Potions refer to anything you drink. You can drink a potion at the same time as 
     • `Should be your primary source of food anywhere with low KO potential.`
 
 .
-> **__Boosts__**
-.tag:potions
-**__Overloads__**
+> **__Overloads__**
+.tag:overload
 ⬥ **Holy Overload** <:holyovl:689551388463595590>
     • Requires level 97 Herblore <:Herblore:689554435583508558>
     • Boosts Attack, Strength, Magic, Ranged and Defence by 15% of each level +3 (up to 116 at level 99)
@@ -107,7 +106,8 @@ Potions refer to anything you drink. You can drink a potion at the same time as 
     • `Worth making as soon as you have the level for them.`
 
 .
-**__Adrenaline Potions__**
+> **__Adrenaline Potions__**
+.tag:apot
 ⬥ **Replenishment Potion** <:replen:634350514406162436>
     • Requires level 87 Herblore <:Herblore:689554435583508558>
     • Gives 25% adrenaline, with a 2 minute cooldown timer.
@@ -125,13 +125,18 @@ Potions refer to anything you drink. You can drink a potion at the same time as 
 ⬥ **Adrenaline renewal potion** <:adrenrenewal:736298121704767538>
     • Requires level 115 Herblore (119 herblore for cheaper recipe use) <:Herblore:689554435583508558>, but these can be assisted.
     • Gives 4% adrenaline per tick for 10 ticks (total of 40% adrenaline).
+        - It is worth being aware of that fact that, excluding sip tick, the adrenaline is applied at the end of the tick, and so cannot be utilized until the tick after
     • `Best-in-Slot Adrenaline potion, for the majority of cases.`
 
 .
-**__Bombs__**
+> **__Bombs__**
+.tag:bomb
+*Note: Bombs being applying their effects 3t (1.8s) after being thrown*
+
+.
 ⬥ **Vulnerability bomb** <:vulnbomb:655341074235129858>
     • Cast range of 9 tiles.
-    • Spreads over a 3x3 area where the Vulnerability effect is applied to monsters standing in it(lasts 1.8 seconds).
+    • Spreads over a 3x3 area where the Vulnerability effect is applied to monsters standing in it (lasts 1.8 seconds).
     • Applies it 3 times (once every 0.6 seconds for a total of 1.8 seconds)
     • The probability of the effect applying is based on the player's current accuracy against the target.
     • `Worth using anywhere you want the target to be vulned without casting the Vulnerability spell directly`
@@ -139,13 +144,13 @@ Potions refer to anything you drink. You can drink a potion at the same time as 
 .
 ⬥ **Sticky bomb** <:stickybomb:655341074306301964>
     • Cast range of 9 tiles.
-    • Spreads over a 3x3 area and binds monsters standing in it(lasts 6 seconds).
+    • Spreads over a 3x3 area and binds monsters standing in it (lasts 6 seconds).
     • `Worth using against stunnable/bindable targets like Magister or Telos and his golems in Phase 4 and 5`
 
 .
 ⬥ **Poison bomb** <:poisonbomb:655341074591645707>
     • Cast range of 9 tiles.
-    • Spreads over a 3x3 area and applies poison to monsters standing in it(lasts 6 seconds).
+    • Spreads over a 3x3 area and applies poison to monsters standing in it (lasts 6 seconds).
     • The poison damage is based on current weapon damage.
     • `Few if any uses.`
 
@@ -354,7 +359,9 @@ This is an example of a general PvM preparation preset used for bonfiring, summo
 .
 > **__Table of Contents__**
 ⬥ **Healing** - $linkmsg_food$
-⬥ **Boosts** - $linkmsg_potions$
+⬥ **Overloads** - $linkmsg_overload$
+⬥ **Adrenaline Potions** - $linkmsg_apot$
+⬥ **Bombs** - $linkmsg_bomb$
 ⬥ **Incense Sticks** - $linkmsg_incense$
 ⬥ **Summoning** - $linkmsg_summ$
 ⬥ **Ammo** - $linkmsg_bakrbolts$


### PR DESCRIPTION
#vindicta: melee rotations → kill 1 rotation specified the gflurry is 2hit
#dpm-advice-mage: updated the hit timing sheet, stated that in 4taa text guide wrack is solely for practice at the start, clarified energizing gains more adrenaline
#boss-revenue: removed the note about rakshas droprates being estimates and unknown
#consumables: broke the Boosts header into 3 different headers for Overloads, Apots, and Bombs; added a note to bombs header that bombs apply effect 3t after cast, and added some missing spaces to bombs section
#bossing-path: Telos part now links to #telos-beginner instead of #telos-0-999-magic
#ed2 and #ed3 melee channels: added mention of corb perk to general notes