### PR TITLE
chore: remove unnecessary brackets in heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ All changes made to guides will live here, and everyone is free to use this info
 ## [Style Guide](style-guide.md)
 If you're interested in contributing, contact Hoobs#3248 or Ry#3050 on discord, or submit a pull request after reading the above style guide.
 
-## [Navigation]
+## Navigation
 The layout of the repository mirrors the layout of the server, so if you're looking to edit a guide, simply navigate as if you were in the discord server.
 


### PR DESCRIPTION
removes unnecessary brackets around the Navigation heading in the README