### PR TITLE
Stuff done is in comments

### DIFF
--- a/commands/damagetroubleshoot.txt
+++ b/commands/damagetroubleshoot.txt
@@ -1,0 +1,13 @@
+**__Common things you might be missing that significantly contribute to your damage__**
+
+⬥ Are you using vulnerability? (bombs or spells)
+⬥ Are you using a zerker aura?
+⬥ Are you using an activated damage pocket slot item?
+⬥ Are you using a ripper demon? With scrolls?
+⬥ If the boss is poisonable, are you using weapon poison+++ and cinderbanes?
+⬥ Are you using a planted feet switch (ranged/mage only), adrenaline potions, and ring of vigour with your ultimates?
+⬥ Are wrack, piercing shot, slice, or punish early on your revolution bar?
+⬥ Do you have divine charges?
+⬥ Do you have the correct prayer active?
+
+Let whomever is helping you know what you are missing from the list and they can help you troubleshoot more from there.

--- a/commands/damagetroubleshoot.txt
+++ b/commands/damagetroubleshoot.txt
@@ -1,5 +1,4 @@
-**__Common things you might be missing that significantly contribute to your damage__**
-
+**__Common Things You Might be Missing that Significantly Contribute to Your Damage__**
 ⬥ Are you using vulnerability? (bombs or spells)
 ⬥ Are you using a zerker aura?
 ⬥ Are you using an activated damage pocket slot item?

--- a/commands/yak.txt
+++ b/commands/yak.txt
@@ -11,7 +11,7 @@ This way, if mechanics are not outright skipped, they're greatly shortened and t
 ⬥ Has a high innate auto-attack damage with a high hitchance for a Combat Familiar.
     • Massively increased damage output when using Death from Above scrolls <:ripperscroll:703581275155464203> (can be stored by using them on the Demon), which is maximized by manually speccing with Spiritual Prayers <:spiritualprayer:651079281882955787>
 
-**__Nihils__** <:IceNihil:513195712163348506>
+**__Nihils__** <:icenihil:854475442164334592>
 ⬥ Increases your hitchance by 5% on its respective style, which is an indirect damage buff as it causes you to splash less.
 
 > **__Pack Mammoth__** <:Mammoth:513195712146702337>

--- a/getting-started/invention-basics.txt
+++ b/getting-started/invention-basics.txt
@@ -194,7 +194,7 @@ Below you'll find a rough guide on what to disassemble for most invention compon
 **__Rare Components__**
 <:Armadylcomp:513190158477033474> **Armadyl** - Armadyl Armour/Weapons
 <:ascendedcomp:583435429848678439> **Ascended** - Sirenic Gear
-<:averniccomp:583435429840420865> **Avernic** - Blade of Avaryss/Nymora, Anima Core of Zaros
+<:averniccomp:583435429840420865> **Avernic** - Blade of Avaryss/Nymora, Anima Core of Zamorak
 <:bandoscomp:583435429861261322> **Bandos** - Bandos Armour/Weapons
 <:brassicancomp:583435429638963205> **Brassican** - A Cabbage
 <:Clockworkcomp:513206171549696000> **Clockwork** - Cannon Parts (obtained at Dwarven Mine)

--- a/miscellaneous-information/mechanics.txt
+++ b/miscellaneous-information/mechanics.txt
@@ -140,10 +140,11 @@ On something like a combat dummy, the true centre is in the centre because the s
 ⬥ **General Graardor** - 3x3
 ⬥ **Giant mole** - 3x3
 ⬥ **Har-Aken** - 5x5
-⬥ **Helwyr **- 5x5
+⬥ **Helwyr** - 5x5
 ⬥ **Kalphite King** - 5x5
 ⬥ **Kalphite Queen** - 5x5
 ⬥ **Kerapac** - 3x3
+⬥ **Kerapac Echos** - 1x1
 ⬥ **King Black Dragon** - 5x5
 ⬥ **Kree'arra** - 3x3
 ⬥ **K'ril Tsutsaroth** - 5x5

--- a/miscellaneous-information/mechanics.txt
+++ b/miscellaneous-information/mechanics.txt
@@ -320,7 +320,6 @@ Comparison of waiting for spawn time x instance hopping: https://youtu.be/O-Lb93
 ⬥ **Target Cycling** - $linkmsg_tc$
 ⬥ **Walking Bosses** - $linkmsg_walking$
 ⬥ **Manual Spellcasting** - $linkmsg_manualspellcasting$
-⬥ **Autocast Spell Selection** - $linkmsg_autocast$
 ⬥ **Boss Centre and AoE** - $linkmsg_centre$
 ⬥ **Boss Sizes for SGB** - $linkmsg_sizes$
 ⬥ **Adren Gain without a Target** - $linkmsg_adrengain$

--- a/miscellaneous-information/mechanics.txt
+++ b/miscellaneous-information/mechanics.txt
@@ -93,15 +93,6 @@ __**Applications**__
     • With the toggle on, the player has increased control over when to bind Telos and potential ping spikes won't have as much of an unintended consequence.
 
 .
-> **__Autocast Spell Selection__ (Courtesy of <@244845124712923137>)**
-.tag:autocast
-**__Ensuring Both Weapons are Casting Spells__**
-⬥ When selecting an autocast spell, be sure to manually select it with dual-wield (main-hand + off-hand). Selecting your autocast with a two-handed weapon will only apply it to the main-hand, thus setting no off-hand spell, causing you to do 2/3 damage when doing dual-wield abilities in this manner.
-
-⬥ Here is a comparison. First example is selecting your autocast with two-handed weapon first (main-hand autocast). Second example is selecting your autocast with dual-wield weapon first (main-hand + off-hand autocast).
-https://youtu.be/IUmvGm4Z374
-
-.
 > **__Boss Centre and AoE__ (Courtesy of <@175995416955977728>)**
 .tag:centre
 **__Boss Center Square is Always South-West__**

--- a/miscellaneous-information/pvm-spreadsheets.txt
+++ b/miscellaneous-information/pvm-spreadsheets.txt
@@ -89,3 +89,11 @@ Disc: https://discord.gg/deqFqtXgNp
 .
 **__Greater Fury vs 188 Comparison Before an Ability__**
 <https://docs.google.com/spreadsheets/d/1beHYkyPKV-tj8eHlbRDQTRX9GkdFBKhBr89B8fKyuXI/edit#gid=1063393167>
+
+.
+**__Ability Prioritisation__**
+<https://docs.google.com/spreadsheets/d/1OetEUz4xU5sg7pqmJBkkafmZIye8qoPOXprUPGhin14/edit?usp=sharing>
+
+.
+**__Ability Damage Maths__**
+<https://docs.google.com/spreadsheets/d/1F5vBijBmZw2aWI-OA0DxV0Iw5efolCx58nqkzGLeqC0/>

--- a/telos/telos-1k-plus-magic.txt
+++ b/telos/telos-1k-plus-magic.txt
@@ -64,7 +64,7 @@ auto cast <:incitefear:856635090783567902> <:dummy:656844963522281473> <:Natural
 ⬥ **For Tendril Clear**
 <:deto:535533833358016512> → <:bloodbarrage:537338981747261446> <:deto:535533833358016512> <:wm:535533809978966037> → <:dbreath:535533833391702017> <:surge:535533810004262912> (towards jump spot)
 
-⬥ _Note: The current rotation with greater concentrated blast phases before tendrils._
+*Note: The current rotation with greater concentrated blast phases before tendrils.*
 
 .
 > **__Phase 2__**

--- a/telos/telos-1k-plus-magic.txt
+++ b/telos/telos-1k-plus-magic.txt
@@ -64,6 +64,8 @@ auto cast <:incitefear:856635090783567902> <:dummy:656844963522281473> <:Natural
 ⬥ **For Tendril Clear**
 <:deto:535533833358016512> → <:bloodbarrage:537338981747261446> <:deto:535533833358016512> <:wm:535533809978966037> → <:dbreath:535533833391702017> <:surge:535533810004262912> (towards jump spot)
 
+⬥ _Note: The current rotation with greater concentrated blast phases before tendrils._
+
 .
 > **__Phase 2__**
 .tag:p2

--- a/vorago/vorago-hardmode.txt
+++ b/vorago/vorago-hardmode.txt
@@ -800,7 +800,7 @@ Rago Hub: https://discord.gg/uqGJbKH
 **__Bomb Tank__**
 ⬥ **Bomb Tank Introduction** - $linkmsg_btintro$
 ⬥ **Bomb Tank P1 & 2** - $linkmsg_btp12$
-⬥ **Bomb Tank P3 - 8**
+⬥ **Bomb Tank P3 - 8** - $linkmsg_btp38$
 
 **__Phases 9, 10, & 11__**
 ⬥ **Weekly Special Mechanics** - $linkmsg_p91011$


### PR DESCRIPTION
Added current p1 rot phases before tendrils with gconc in telos 1k+ magic
sizes for sgb section: state kerapac echos are 1x1
!yak command: fix broken ice nihil emoji
#invention basics rare comps section: say it is anima zammy that gives avernic, not zaros
#mechanics: remove the "Autocast Spell Selection" section
#pvm-spreadsheets: shift all relevant sheets from #ability-damage-maths to it then archive the channel
Add a !damagetroubleshoot command
#vorago-hardmode, ToC, BT section: BT P3-P8 missing the link to the respective section
#mechanics, zerk + aura interactions: reword
#armour-and-weapons: add kerapac gloves
#upgrade-order: replace sirenic for sup morrigans (or elite robin)
#magister, familiar choice section: fix broken zerk aura emoji