### PR TITLE
Stating ecb disallows casting spec w/o target if queuing in relevant channels

### DIFF
--- a/commands/ecbeof.txt
+++ b/commands/ecbeof.txt
@@ -19,5 +19,6 @@
 ⬥ It is also harder to use because you will be using more switches overall.
     • An additional EoF <:eofpink:780401412865523722> and off-hand to account for.
     • -2 inventory spaces. Given you'd still want to bring a 2h weapon.
+⬥ If using queueing, then you cannot use the special without a target
 
 **Disclaimer: The first drawback is very relevant to Nex. Do not get an ECB EoF until you either finish your grind or acquire a second ECB.**

--- a/dpm-advice/dpm-advice-range.txt
+++ b/dpm-advice/dpm-advice-range.txt
@@ -721,6 +721,7 @@ The Essence of Finality <:eofor:745279787471470713> is an Alchemical Hydrix jewe
 ⬥ It is also harder to use because you will be using more switches overall.
     • An additional EoF <:eofpink:780401412865523722> and off-hand to account for.
     • -1 inventory space
+⬥ If using queueing, then you cannot use the special without a target
 
 *Note: The first drawback to an ECB EoF <:ecb:615618531937222657> <:eofpink:780401412865523722> is very relevant to Nex. Do not get an ECB EoF <:ecb:615618531937222657> <:eofpink:780401412865523722> until you either finish your grind or acquire a second Eldritch Crossbow <:ecb:615618531937222657>.*
 

--- a/miscellaneous-information/eof-specs.txt
+++ b/miscellaneous-information/eof-specs.txt
@@ -52,6 +52,7 @@ The Essence of Finality <:eof:787526151978614824> <:eofor:745279787471470713> is
     • Costs 25% adrenaline
     • For 15 seconds (25 ticks), soulsplit <:soulsplit:615613924506599497> deals 4x the amount of healing you would have gotten as damage against your target
     • Switching mainhand weapons will end the effect, but switching amulets will not.
+    • If using queueing, then you cannot use the special without a target
 ⬥ What <:eofspec:746403211908481184> lets you do that you normally cannot
     • ECB spec with 1h/DW/Chins (allows Needle Strike <:needle:535541259108876293> and Flanking <:flank4:712073088296157185> <:bindingshot:535541306563231790> <:tight:535541275957657600> under ECB spec)
 ⬥ Scenarios it is used


### PR DESCRIPTION
Issue #1922 