### PR TITLE
#upgrade-order, mage: removed ful, and move t99 prayer before etect

### DIFF
--- a/upgrading-info/upgrade-order.txt
+++ b/upgrading-info/upgrade-order.txt
@@ -1,7 +1,7 @@
 > __**Introduction**__
 .tag:intro
 This channel lists the **general** natural combat style progression template for players to follow.
-**Last Revised: November 29th 2021**
+**Last Revised: November 30th 2021**
 
 .
 > **__Disclaimer__**
@@ -62,7 +62,7 @@ If you would like specialized advice, ask in <#656898197561802760>.
     • Only pick up a <:reaverring:839903943018283050> if it does not significantly push you below 100% hitchance, you can use !hitchance in <#534563158304620564> to check this
 ⬥ Limitless <:limitless:641339233638023179>
 ⬥ Biting 4 <:biting4:712073087809617931>
-⬥ Scripture of Wen/Ful <:scriptureofwen:883134307902816297> / <:scriptureofful:902209626412560395>
+⬥ Scripture of Wen <:scriptureofwen:883134307902816297>
 ⬥ Inquisitor Staff <:inquisitorstaff:694566917553520680>
     • If doing content that benefits from it
 ⬥ P6AS1 + AS4E2 (or P6R1 on staff) <:p6:712073088769982475><:as1:689502339891331093> <:as4:712074245202772009><:eq2:689502258424971564> <:ruthless1:712244800924942396>
@@ -71,6 +71,7 @@ If you would like specialized advice, ask in <#656898197561802760>.
 ⬥ Fractured Staff of Armadyl + Essence of Finality (with Armadyl Battlestaff stored) <:soa:869284271595069451> + <:eofyellow:780401412902223892> (with <:armadylbattlestaff:881962727705280512>)
 .
 **__Stage 3: Pretty Low ROI__**
+⬥ Affliction <:Affliction:513190158468907008>
 ⬥ Upgrade to T92 Armour <:elitetectbody:552955120707698699>
 ⬥ Cryptbloom <:cryptbloombody:892819107253194762>
     • Skip if not doing AFK content / learning content
@@ -78,7 +79,6 @@ If you would like specialized advice, ask in <#656898197561802760>.
     • Skip if not planning to do aoe content.
     • If planning to do Elite Dungeons / Zuk, you will also need a Caroming 4 <:caroming4:791281588792590336> switch.
 ⬥ Seismic Singularity <:seissing:583430011831189527>
-⬥ Affliction <:Affliction:513190158468907008>
 ⬥ Wand of the Praesul <:praeswand:643166769518739477>
 ⬥ Upgrade to Flanking 4 Equilibrium 1 <:flank4:712073088296157185> <:eq1:689504357414207490>
     • Primarily for group based content, with some niche solo uses, skip if these do not pertain to you.


### PR DESCRIPTION
Reasoning for changes: 
**Ful remove**
It's basically replaced by grim eventually anyway so dropping 400m on it kinda illogical. Wen stays because its far cheaper, still technically better than scrims, and can see sufficient usage for content you wouldnt grim (i.e., afk methods)

**T99 before etect**
T99 prayer is ~800m for ~1.5% dps increase (before accuracy)
T92 armor is ~400m for ~0.5% dps increase (over t88) + some armor

T99 prayer is 2x the cost for atleast 3x the damage increase so it makes more sense to put it before etect