### PR TITLE
Gconc Command Update to include FSOA/"Either"

### DIFF
--- a/commands/gconc.txt
+++ b/commands/gconc.txt
@@ -6,7 +6,7 @@
     "fields": [
 	  {
         "name": "__Magic or Ranged__",
-        "value": "⬥ If you have gConc <:gconc:869285393223254107> unlocked, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107> and gRico <:gricocaroming:867678153966878740>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107>, gRico <:gricocaroming:867678153966878740>, and ECB <:ecb:615618531937222657>, Ranged <:Ranged:689504724403486920>"
+        "value": "⬥ If you have gConc <:gconc:869285393223254107>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107> and gRico <:gricocaroming:867678153966878740>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107>, gRico <:gricocaroming:867678153966878740>, and ECB <:ecb:615618531937222657>, either <:Magic:689504724159823906> <:Ranged:689504724403486920>\n⬥ At top end, <:soa:869284271595069451> <:gconc:869285393223254107> <:gricocaroming:867678153966878740> <:ecb:615618531937222657>, situational."
       }
     ]
   }

--- a/commands/gconc.txt
+++ b/commands/gconc.txt
@@ -6,7 +6,7 @@
     "fields": [
 	  {
         "name": "__Magic or Ranged__",
-        "value": "⬥ If you have gConc <:gconc:869285393223254107>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107> and gRico <:gricocaroming:867678153966878740>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107>, gRico <:gricocaroming:867678153966878740>, and ECB <:ecb:615618531937222657>, either <:Magic:689504724159823906> <:Ranged:689504724403486920>\n⬥ At top end, <:soa:869284271595069451> <:gconc:869285393223254107> <:gricocaroming:867678153966878740> <:ecb:615618531937222657>, situational."
+        "value": "⬥ If you have gConc <:gconc:869285393223254107>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107> and gRico <:gricocaroming:867678153966878740>, Magic <:Magic:689504724159823906>\n⬥ If you have gConc <:gconc:869285393223254107>, gRico <:gricocaroming:867678153966878740>, and ECB <:ecb:615618531937222657>, either <:Magic:689504724159823906> <:Ranged:689504724403486920>\n⬥ At top end, <:gconc:869285393223254107> <:soa:869284271595069451> <:gricocaroming:867678153966878740> <:ecb:615618531937222657>, situational"
       }
     ]
   }


### PR DESCRIPTION
Gconc command doesn't include higher end i.e. FSOA. Change third row to be "either", and add a fourth row to be "situational" at top end.