### PR TITLE
Update eof-specs.txt

### DIFF
--- a/miscellaneous-information/eof-specs.txt
+++ b/miscellaneous-information/eof-specs.txt
@@ -51,9 +51,8 @@ The Essence of Finality <:eof:787526151978614824> <:eofor:745279787471470713> is
 **__Eldritch Crossbow__** <:ecb:615618531937222657> <:eofpink:780401412865523722>
 ⬥ Special Attack: __Split Soul__
     • Costs 25% adrenaline
-    • For 15 seconds (25 ticks), soulsplit <:soulsplit:615613924506599497> deals 4x the amount of healing you would have gotten as damage against your target
-    • Switching mainhand weapons will end the effect, but switching amulets will not.
-    • If using queueing, then you cannot use the special without a target
+    • For 15 seconds (25 ticks), Soul Split <:soulsplit:615613924506599497> no longer heals you, but deals 4x the amount of healing you would have gotten as damage against your target
+    • Switching mainhand weapons will end the effect, but switching offhand weapons or amulets will not.
 ⬥ What <:eofspec:746403211908481184> lets you do that you normally cannot
     • ECB spec with 1h/DW/Chins (allows Needle Strike <:needle:535541259108876293> and Flanking <:flank4:712073088296157185> <:bindingshot:535541306563231790> <:tight:535541275957657600> under ECB spec)
 ⬥ Scenarios it is used

--- a/miscellaneous-information/eof-specs.txt
+++ b/miscellaneous-information/eof-specs.txt
@@ -54,7 +54,8 @@ The Essence of Finality <:eof:787526151978614824> <:eofor:745279787471470713> is
     • For 15 seconds (25 ticks), Soul Split <:soulsplit:615613924506599497> no longer heals you, but deals 4x the amount of healing you would have gotten as damage against your target
     • Switching mainhand weapons will end the effect, but switching offhand weapons or amulets will not.
 ⬥ What <:eofspec:746403211908481184> lets you do that you normally cannot
-    • ECB spec with 1h/DW/Chins (allows Needle Strike <:needle:535541259108876293> and Flanking <:flank4:712073088296157185> <:bindingshot:535541306563231790> <:tight:535541275957657600> under ECB spec)
+    • ECB spec with 1h/DW/Chins
+        - Allows Needle Strike <:needle:535541259108876293>, the use of Flanking <:flank4:712073088296157185>, and the ability to use Caroming <:caroming4:791281588792590336> as a switch
 ⬥ Scenarios it is used
     • Anywhere you use Ranged <:range:580168050121113623>
 ⬥ Priority/usefulness (at said scenarios):


### PR DESCRIPTION
Made some changes to ECB EOF: explicitly mentioned that offhand weapon swapping doesn't cancel since this is a major benefit; removed the section about queuing disallowing use of the spec without a target since this was fixed late last year; clarified that the special stops SS healing.