### PR TITLE
Correctly capitalise RuneScape

### DIFF
--- a/information/how-to.txt
+++ b/information/how-to.txt
@@ -18,16 +18,16 @@ Our social channels are located here:
   }
 }
 .embed:json
-Followed by our Runescape channels, split into two categories:
+Followed by our RuneScape channels, split into two categories:
 .tag:channels
 {
   "embed": {
-    "title": "Runescape channels",
-    "description": "These channels are Runescape related, for players to find help or post their achievements",
+    "title": "RuneScape channels",
+    "description": "These channels are RuneScape related, for players to find help or post their achievements",
     "color": 39423,
     "fields": [
       {
-        "name": "Runescape Channels",
+        "name": "RuneScape Channels",
         "value": "<#656898197561802760>\n<#557699151291351060>\n<#536062588090318850>\n<#538137911292329986>\n<#534563158304620564>",
 	"inline": true
       },


### PR DESCRIPTION
Game's name is capitalised as "RuneScape" and not "Runescape"