### PR TITLE
vorago guide changes

### DIFF
--- a/vorago/basic/Duo_PB_combined.txt
+++ b/vorago/basic/Duo_PB_combined.txt
@@ -346,7 +346,6 @@ __**Phase 2**__
 ⬥ Time gated. Handle mechanics, reduce food usage, throw <:Shard:583429757975396366>.
 ⬥ Get Vorago's HP to under 30k before Bring Him Down.
 ⬥ BHD is 6 GCDs → [wait 1 tick] → <:Shatter:583429757761224715>
-⬥ If <:disrupt:535614336207552523> is owned it can be used after Vorago is killed at the end of this phase to block some damage in Phase 3
 
 __Base Tank__
 ⬥ Lure Vorago into base spot.

--- a/vorago/basic/Duo_TS_combined.txt
+++ b/vorago/basic/Duo_TS_combined.txt
@@ -340,7 +340,6 @@ __**Phase 2**__
 ⬥ Time gated. Handle mechanics, reduce food usage, throw <:Shard:583429757975396366>.
 ⬥ Get Vorago's HP to under 30k before Bring Him Down.
 ⬥ BHD is 6 GCDs → [wait 1 tick] → <:Shatter:583429757761224715>
-⬥ If <:disrupt:535614336207552523> is owned it can be used after Vorago is killed at the end of this phase to block some damage in Phase 3
 
 __Base Tank__
 ⬥ Lure Vorago into base spot.

--- a/vorago/vorago.txt
+++ b/vorago/vorago.txt
@@ -177,19 +177,23 @@ __**Before The Fight**__
     • Top Lure Voke 5: Often abbreviated as TL5/TLV5, or referred to as the "jump/jumper". Climbs Vorago on phase 1 and handles the 5th bleed during phases 2 and 4.
 
 .
-⬥ Entry damage is 12.5k for any team with 4 or less players.
+⬥ Entry damage is 70% of your max life points regardless of team size.
     • This damage also cancels defensive abilities, and the <:EnhancedExcalibur:513200949016264727> healing effect.
         - Use <:disrupt:535614336207552523> and <:EnhancedExcalibur:513200949016264727> after taking the entry damage
 
-⬥ There are about 20s between challenge and entry damage. Advanced players can use this time to use <:nat:535541258131865633>.
-    • There are 49 ticks from challenging Vorago to Target Cycle, and 48 ticks from the Accept Challenge message to Target Cycle.
-    • Drop down damage is 33 ticks after challenging Vorago.
+⬥ There are 12s between challenge and entry damage. Advanced players can use this time to use <:nat:535541258131865633>.
+    • There are 36 ticks from challenging Vorago to Target Cycle, and 35 ticks from the Accept Challenge message to Target Cycle.
+    • Drop down damage is 20 ticks after challenging Vorago.
     • Sample <:nat:535541258131865633> rotation:
 .
 .img:https://i.imgur.com/JycYCl7.mp4
 .
-⬥ To time <:vitality:654618235097972737>, use a 20s cooldown ability such as <:prep:535541258546970624> after challenging Vorago/accepting challenge. When the cooldown is 3/4 done, use <:vitality:654618235097972737>.
+⬥ To time <:vitality:654618235097972737>, use it 20 ticks after challenging Vorago/accepting challenge.
+    • This can be done by counting each tick from when you challenge by looking at prayer point drain
+    • It can also be done by looking at the bar above Vorago and clicking on it when it is about to fill, as in the following clip:
 
+.
+<https://www.youtube.com/watch?v=MG00fhlSnKA>
 .
 __**During The Fight**__
 ⬥ Vorago has two basic auto attacks: **Melee Swipes** and **Blue Bombs**
@@ -378,14 +382,14 @@ __**Vorago's Attack Rotation**__
 .img:https://i.imgur.com/pPNE2a2.png
 .
 __**General Phase Notes**__
-⬥ Phase 2 is time gated. In order to progress the phase, Vorago must absorb at least four Gravity Orbs, which spawn on Reflect. Thus, at least four Reflect special attacks are required.
+⬥ Phase 2 is time gated. In order to progress the phase, Vorago must absorb at least two Gravity Orbs, which spawn on Reflect. Thus, at least two Reflect special attacks are required.
     • Since this phase is time gated, use as many defensives as necessary to avoid using food at all during this phase.
 
 ⬥ Because this phase is time gated, damage dealt is largely irrelevant. The only notable damage benchmark is to reduce Vorago's HP to under 25k before the final Reflect.
     • DPS ultimates can be skipped. However, they can be used for anyone competing for drops.
 
 ⬥ Stack <:Shard:583429757975396366>, and use affinity-increasing abilities to increase hit chance.
-    • Up to 6 <:Shard:583429757975396366> can be thrown per player. An additional one can be thrown during Bring Him Down.
+    • Up to 4 <:Shard:583429757975396366> can be thrown per player. An additional one can be thrown during Bring Him Down.
 
 .
 __**Smash Bleed Notes**__
@@ -428,9 +432,9 @@ __**Gravity Orb Notes**__
 At the start of every Reflect, Vorago will spawn a Gravity Orb.
 ⬥ Clicking on a Gravity Orb will cause Vorago to absorb it.
 
-⬥ A total of 4 Gravity Orbs are required to finish the phase.
+⬥ A total of 2 Gravity Orbs are required to finish the phase.
 
-⬥ If a Gravity Orb is not clicked before the next Reflect, a second Gravity Orb will not spawn. Vorago must use an additional Reflect to spawn the required 4 Gravity orbs. This should be avoided.
+⬥ If a Gravity Orb is not clicked before the next Reflect, a second Gravity Orb will not spawn. Vorago must use an additional Reflect to spawn the required 2 Gravity orbs. This should be avoided.
 
 ⬥ Gravity Orbs have limited range. Vorago must be close enough to each Gravity Orb, or the orb will not be absorbed.
 
@@ -447,8 +451,8 @@ __**Red Bomb Notes**__
 ⬥ Because Red Bombs cancel defensive abilities and put them on cooldown, the Bomb Tank can take significant damage during this phase.
 
 ⬥ <:cade:535541306353778689> + <:Cept:543478434509357098> + <:HealOther:567727985851891715> is commonly used during Red Bombs to mitigate damage and food usage.
-    • Either the Base Tank or the Bomb Tank will use <:cade:535541306353778689> on the first and the third Red Bombs, and the other player will use <:cade:535541306353778689> on the second.
-    • The Bomb Tank should force the Red Bomb onto someone else when it's the Bomb Tank's turn to use <:cade:535541306353778689>.
+    • Either the Base Tank or the Bomb Tank will use <:cade:535541306353778689> on the Red Bomb
+    • The Bomb Tank can force the Red Bomb onto someone else if they are going to use <:cade:535541306353778689>.
         - To force a Red Bomb, the Bomb Tank should move closer to Vorago so that someone else is the furthest player from Vorago. Start moving immediately after the third attack during Reflect.
         - In duos, the Bomb Tank will need to move either melee distance or underneath Vorago to force the Red Bomb onto the Base Tank.
 


### PR DESCRIPTION
- update main vorago guide according to p0/p2 changes
- remove mention of disrupt on p2 teamsplit in basic guide (quick guide)
- remove mention of disrupt on p2 purple bomb in basic guide (quick guide)