### PR TITLE
#armour-and-weapons: applied some feedback

### DIFF
--- a/upgrading-info/armour-and-weapons.txt
+++ b/upgrading-info/armour-and-weapons.txt
@@ -15,12 +15,12 @@
 {
   "embed": {
     "title": "__Index of Armour__",
-    "description": "⬥ It is recommended to look up further information on the [Wiki](https://runescape.wiki/)\n⬥ Armour in **bold** is worth being aware of, they will be elaborated on after\n⬥ Use `!armour` to see DPS difference between the armour",
+    "description": "⬥ It is recommended to look up further information on the [Wiki](https://runescape.wiki/)\n⬥ Armour in **bold** is worth being aware of, they will be elaborated on after\n⬥ Use `!armour` to see DPS difference between the armour\n⬥ Generally speaking, use **power armour**",
     "color": 39423,
     "fields": [
       {
         "name": "__Power Armour__",
-        "value": "⬥ GWD1 Armour <:Subjugation:513190159429402664> (T70)\n⬥ Nex Armour <:VirtusTop:556586038936600603>\n⬥ Ancient Warrior <:zurieltop:1004090526250827867> (T78)\n\u00a0\u00a0\u00a0\u00a0• Superior <:SuperiorZurielstop:556586037216804864> is T88\n (T80)\n⬥ Anima Armour <:animabodyseren:923248695846273054> (T80)\n\u00a0\u00a0\u00a0\u00a0• Refined is T85\n⬥ Elite Robinhood <:EliteRobinHoodTop:556585903489810454> (T82)\n⬥ Tectonic <:tectbody:643849268804714506> (T90)\n\u00a0\u00a0\u00a0\u00a0• Elite <:elitetectbody:552955120707698699> is T92\n⬥ Sirenic <:sirenicbody:643846948570267648> (T90)\n\u00a0\u00a0\u00a0\u00a0• Elite <:elitesirenicbody:643846908305211413> is T92\n⬥ Masterwork <:masterworkbody:643847056527458324> (T90)\n\u00a0\u00a0\u00a0\u00a0• Trimmed <:tmwbody:643847118196441088> is T92\n⬥ Malevolent <:malevbody:643846996842512405> (T90)\n⬥ **Vestments of Havoc** <:vestmentsofhavoctop:994189295592161291> (T95)",
+        "value": "⬥ GWD1 Armour <:Subjugation:513190159429402664> (T70)\n⬥ Ancient Warrior <:zurieltop:1004090526250827867> (T78)\n\u00a0\u00a0\u00a0\u00a0• Superior <:SuperiorZurielstop:556586037216804864> is T88\n⬥ **Nex Armour** <:VirtusTop:556586038936600603> (T80)\n⬥ Anima Armour <:animabodyseren:923248695846273054> (T80)\n\u00a0\u00a0\u00a0\u00a0• Refined is T85\n⬥ Elite Robinhood <:EliteRobinHoodTop:556585903489810454> (T82)\n⬥ Tectonic <:tectbody:643849268804714506> (T90)\n\u00a0\u00a0\u00a0\u00a0• Elite <:elitetectbody:552955120707698699> is T92\n⬥ **Sirenic** <:sirenicbody:643846948570267648> (T90)\n\u00a0\u00a0\u00a0\u00a0• Elite <:elitesirenicbody:643846908305211413> is T92\n⬥ Masterwork <:masterworkbody:643847056527458324> (T90)\n\u00a0\u00a0\u00a0\u00a0• Trimmed <:tmwbody:643847118196441088> is T92\n⬥ Malevolent <:malevbody:643846996842512405> (T90)\n⬥ **Vestments of Havoc** <:vestmentsofhavoctop:994189295592161291> (T95)",
         "inline": true
       },
       {
@@ -33,9 +33,11 @@
 }
 .embed:json
 **__Notable Armour__**
+⬥ <:vestmentsofhavoctop:994189295592161291> has effects that greatly benefit melee. Should be used over <:tmwbody:643847118196441088>. Does T100 damage and has armour equal to T75 power armour
+⬥ <:sirenicbody:643846948570267648> is solid cheap ranged power armour
+⬥ <:VirtusTop:556586038936600603> (Virtus) is solid cheap magic power armour
 ⬥ <:ganobody:1003947805611655208> is very cheap magic tank gear to use with Animate Dead <:animatedead:856635090453135382>
 ⬥ <:cryptbloombody:892819107253194762> is the best tank armour in game, but not always needed - see `!crypt`
-⬥ <:vestmentsofhavoctop:994189295592161291> has effects that greatly benefit melee. Should be used over <:tmwbody:643847118196441088>. Does T100 damage and has armour equal to T75 power armour
 
 .
 **__Gloves__**
@@ -43,7 +45,7 @@
 {
   "embed": {
     "title": "__Gloves__",
-    "description": "⬥ Use `!gloves` to see where to use which gloves\n⬥ <:lengartefact:884739993543782420> upgrades <:nightmaregauntlets:513190159441723392> / <:Glovesofpassage:556588694862037012> / <:kerapacswristwraps:869286640722513940> to T90 and allows enchantments to work\n ⬥ Gloves covered: <:kerapacswristwraps:869286640722513940> | <:NMG:513190159441723392> | <:glovespassage:643166351585706060> | <:Cinderbanes:513190158355660812> | <:DTB:513190159429271562> | <:spellcaster:643214402169864213>",
+    "description": "⬥ Use `!gloves` to see where to use which gloves\n⬥ <:lengartefact:884739993543782420> upgrades <:nightmaregauntlets:513190159441723392> / <:Glovesofpassage:556588694862037012> / <:kerapacswristwraps:869286640722513940> to T90 and allows enchantments to work\n\u00a0\u00a0\u00a0\u00a0• The T90 gloves can also be bought directly from the G.E.\n ⬥ Gloves covered: <:kerapacswristwraps:869286640722513940> | <:NMG:513190159441723392> | <:glovespassage:643166351585706060> | <:Cinderbanes:513190158355660812> | <:DTB:513190159429271562> | <:spellcaster:643214402169864213>",
     "color": 39423,
     "fields": [
       {
@@ -56,7 +58,7 @@
       },
       {
         "name": "__Gloves of Passage__ <:glovespassage:643166351585706060>",
-        "value": "⬥ After <:havoc:535532879300526080> / <:smash:535532879820619786> are cast the following occurs:\n\u00a0\u00a0\u00a0\u00a0• The next attack deals 10% (16% using **agony enchantment**) more damage\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0- Affects non-bleed attacks cast that tick, bleeds snipe it for no benefit\n\u00a0\u00a0\u00a0\u00a0• Bleeds deal 20% (25% using **agony enchantment**) more damage for 10s\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0- Does not affect <:comb:535533833098100745> / <:corruptblast:513190159194259467> / <:corruptshot:535541306294796299> / <:gbarge:535532879250456578> \"bleeds\""
+        "value": "⬥ After <:havoc:535532879300526080> / <:smash:535532879820619786> are cast the following occurs:\n\u00a0\u00a0\u00a0\u00a0• The next attack deals 10% (16% using **agony enchantment**) more damage\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0- Affects non-bleed attacks cast that tick, bleeds snipe it for no benefit\n\u00a0\u00a0\u00a0\u00a0• Bleeds deal 20% (25% using **agony enchantment**) more damage for 10s\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0- Does not affect <:comb:535533833098100745> / <:corruptblast:513190159194259467> / <:corruptshot:535541306294796299> / <:gbarge:535532879250456578> \"bleeds\" as they are **not** bleeds"
       },
       {
         "name": "__Misc. Gloves__",
@@ -78,7 +80,7 @@
     "fields": [
       {
         "name": "__Boots__",
-        "value": "⬥ **Blast Diffusion Boots** <:detoboots:602581956072439828> - <:deto:535533833358016512> charges 40%/tick instead of 20%/tick\n⬥ **Laceration Boots** <:Laceration:602581988599398400> - Can use <:bd:535532854281764884> with only a MH or 2H melee weapon\n⬥ **Fleeting Boots** <:fleetingboots:789813993480388640> - <:rapid:535541270521708566> has +10% hitchance and can be walked\n\u00a0\u00a0\u00a0\u00a0• Bug: losing line of sight with target prevents movement until <:rapid:535541270521708566> ends"
+        "value": "⬥ **Blast Diffusion Boots** <:detoboots:602581956072439828> - <:deto:535533833358016512> charges 40%/tick instead of 20%/tick\n⬥ **Laceration Boots** <:Laceration:602581988599398400> - Can use <:bd:535532854281764884> with only a MH or 2H melee weapon\n⬥ **Fleeting Boots** <:fleetingboots:789813993480388640> - <:rapid:535541270521708566> has +10% hitchance and can be walked"
       },
       {
         "name": "__Capes__",
@@ -184,6 +186,7 @@
 **__Notable Weapons__**
 ⬥ <:noxscythe:513190159341322240> is BiS halberd where <:lanispear:839903893177106454> splashes
 ⬥ <:noxbow:513190159425208342> is a solid 2H to use until <:sgb:626466665848242186> / <:bolg:994189289623662702>
+⬥ <:abyssalscourge:947871842469834832> generally BiS melee MH due to parasite stacks, see `!scourge` for more info
 ⬥ <:masterworkspearofannihilation:694566917456789554> adds 2 hits to <:dismember:535532879376023572>, <:slaughter:535532879237873666>, and <:BloodTend:513190158431158274> and 3 hits to <:zekkil:903244090953588787> <:eofspec:746403211908481184>
 ⬥ <:sgb:626466665848242186> best 2H until <:bolg:994189289623662702>. Has a strong special attack, see `!sgb` for some more info
 ⬥ <:ecb:615618531937222657> has a very strong special attack, but is relatively hard to use well
@@ -238,7 +241,7 @@
       },
       {
         "name": "__Channeler's Ring__ <:channellerring:839903943404027914>",
-        "value": "⬥ Each hit of a <:Magic:689504724159823906> channel has (4 * channel hits done)% more crit chance\n⬥ **Metaphysics enchantment** increases the 4 to 6.5"
+        "value": "⬥ Each hit of a <:Magic:689504724159823906> channel has (4 * channel hits done)% more crit chance\n⬥ **Metaphysics enchantment** causes +(2.5 * channel hits done) % crit dmg\n⬥ To clarify: <:channellerring:839903943404027914> and its enchantment **only affect <:Magic:689504724159823906> channels, not autos, etc.**"
       },
       {
         "name": "__Champion's Ring__ <:championring:839903943630520350>",


### PR DESCRIPTION
• Added sirenic and virtus as notable armor as well as added a note about power > tank (to make it clearer that power is better)
• Added scourge to notable weapons
• Fixed enchantment effect of channeler ring
• Removed LOS bug from fleeting
• Added note about how T90 glove variants can be bought from GE
• Fixed placement of nex armour in the index
• Clarified the reason certain things were not affected by gop bleed boost effect (i.e. not bleeds)
• Probably something else i am forgetting