### PR TITLE
Update interface-guide.txt

### DIFF
--- a/getting-started/interface-guide.txt
+++ b/getting-started/interface-guide.txt
@@ -363,6 +363,7 @@ __**Modifier Keys**__.
 ⬥ This increases the range of available keybinds.
 ⬥ If using a mouse, you can bind `Modifier+Key` to a single mouse button, making it easier to press.
 *Note: If you release the modifier before the key first, it will trigger the underlying key press. Keep this in mind when setting up modifier keys.*
+⬥ Linux users, most remapping software for gaming mice only works on windows/mac.  Logitech mouse users have an open source option called logiops.  Find it in your favorite distro's repository (in chaotic aur for Arch users for example) or look at their github:  https://github.com/PixlOne/logiops   Note that other options such as xbindkeys or input-remapper will not work to actually hold down a a mouse key and have it act like holding down shift or control, they can only do a one time click, not a hold, despite what their documentation says.
 
 .
 __**Keybinds Guide**__ (Courtesy of <@158292421724209152>)

--- a/getting-started/interface-guide.txt
+++ b/getting-started/interface-guide.txt
@@ -363,8 +363,8 @@ __**Modifier Keys**__.
 ⬥ This increases the range of available keybinds.
 ⬥ If using a mouse, you can bind `Modifier+Key` to a single mouse button, making it easier to press.
 *Note: If you release the modifier before the key first, it will trigger the underlying key press. Keep this in mind when setting up modifier keys.*
-⬥ Linux users, most remapping software for gaming mice only works on windows/mac.  Logitech mouse users have an open source option called logiops.  Find it in your favorite distro's repository (in chaotic aur for Arch users for example) or look at their github:  https://github.com/PixlOne/logiops   Note that other options such as xbindkeys or input-remapper will not work to actually hold down a a mouse key and have it act like holding down shift or control, they can only do a one time click, not a hold, despite what their documentation says.
-***Disclaimer**: logiops is a third party tool, and while generally safe to use, is still recommended to be installed and used at your own risk.*
+⬥ For Linux users: most remapping software for gaming mice only works on Windows/Mac. Logitech mouse users have an open source option called *logiops*. Find it in your favorite distro's repository (e.g. Chaotic-Aur for Arch Linux users) or look at their repository at <https://github.com/PixlOne/logiops>. Note that other options such as *xbindkeys* or *input-remapper* will not work to actually hold down a a mouse key and have it act like holding down `Shift` or `Control`, they can only do a one-time click, not extended holds, despite what their documentation says. Lastly, there are also other alternatives such as *Piper* for consideration.
+***Disclaimer**: These are third party tools, and as always are recommended to be installed and used at your own risk.*
 
 .
 __**Keybinds Guide**__ (Courtesy of <@158292421724209152>)

--- a/getting-started/interface-guide.txt
+++ b/getting-started/interface-guide.txt
@@ -364,6 +364,7 @@ __**Modifier Keys**__.
 ⬥ If using a mouse, you can bind `Modifier+Key` to a single mouse button, making it easier to press.
 *Note: If you release the modifier before the key first, it will trigger the underlying key press. Keep this in mind when setting up modifier keys.*
 ⬥ Linux users, most remapping software for gaming mice only works on windows/mac.  Logitech mouse users have an open source option called logiops.  Find it in your favorite distro's repository (in chaotic aur for Arch users for example) or look at their github:  https://github.com/PixlOne/logiops   Note that other options such as xbindkeys or input-remapper will not work to actually hold down a a mouse key and have it act like holding down shift or control, they can only do a one time click, not a hold, despite what their documentation says.
+***Disclaimer**: logiops is a third party tool, and while generally safe to use, is still recommended to be installed and used at your own risk.*
 
 .
 __**Keybinds Guide**__ (Courtesy of <@158292421724209152>)


### PR DESCRIPTION
Keymapping for modifier keys tip addition added with advice for how to get mouse key mapping to work when users are playing Runescape on a Linux machine.