### PR TITLE
fixed typo in permanent_unlocks.txt

### DIFF
--- a/upgrading-info/permanent-unlocks.txt
+++ b/upgrading-info/permanent-unlocks.txt
@@ -197,7 +197,7 @@ Refer to to the **Starter Perks** or **Advanced PvM Perks** section of <#5536327
     "fields": [
       {
         "name": "__Animal Perks__",
-        "value": "⬥ **NopeNopeNope** <:araxytespider:643507882150592553> - +2% (+3%) damage against spiders + <:Araxxi:513213019543699466> | 64 <:Farming:513213693790519307>\n⬥ **King of Beasts** <:bagrada:690136116992671875> - 5% (10%) chance to save a thrown bomb | 106 <:Farming:513213693790519307>\n⬥ **No Fear** <:corbicula:690136117273821280> - +20% (+40%) crit chance to <:meteorstrike:535532879359377439> | 112 <:Farming:513213693790519307>\n⬥ **Armoured Hide** <:malletops:690136117374484508> - +1.8s (+3.6s) duration to <:cade:535541306353778689> | 118 <:Farming:513213693790519307>"
+        "value": "⬥ **NopeNopeNope** <:araxytespider:643507882150592553> - +2% (+3%) damage against spiders + <:Araxxi:513213019543699466> | 64 <:Farming:513213693790519307>\n⬥ **King of Beasts** <:bagrada:690136116992671875> - 5% (10%) chance to save a thrown bomb | 106 <:Farming:513213693790519307>\n⬥ **No Fear** <:corbicula:690136117273821280> - +20% (+40%) crit chance to <:meteorstrike:535532879359377439> | 112 <:Farming:513213693790519307>\n⬥ **Armoured Hide** <:malletops:690136117374484508> - +1.8s (+3.6s) duration to <:cade:535541306353778689> | 117 <:Farming:513213693790519307>"
       }
     ]
   }


### PR DESCRIPTION
Channel said that Malletops perk requires 118 farming
Wiki and in-game guides say Malletops are unlocked at 117 farming