### PR TITLE
Update abyssal-creatures.txt

### DIFF
--- a/slayer/abyssal-creatures.txt
+++ b/slayer/abyssal-creatures.txt
@@ -173,7 +173,7 @@ Abyssal lords are by far the best abyssal creatures task for both exp and gp. Du
 **__Preset__**
 **__Magic__**
 ⬥ <:noxstaff:513190159294922753> T90+ staff with C4PF + E4R3 (your best staff should work fine if T90 or above)
-⬥ <:runic:643505377211842582> Runic or <:vamp:643505653079343144> Vampyrism aura
+⬥ <:vamp:643505653079343144> Vampyrism or <:runic:643505377211842582> Runic aura
 ⬥ <:graspingpouchblack:892816436974735361> **Rune Pouch** <:Bloodrune:536252658970001409> <:Astralrune:536252658961481769> <:Bodyrune:536252659301089280> <:Firerune:536252659850674186>
 ⬥ <:graspingpouchpink:892816437503221830> **Rune Pouch** <:Deathrune:536252659586433024> <:Earthrune:536252659808731137> <:Lawrune:536252661406760970> <:Cosmicrune:536252659615924258>
 ⬥ <:graspingpouchblue:892816437406728252> **Rune Pouch** <:Chaosrune:536252659422855188> <:Airrune:536252658986647589> <:Waterrune:536252660165115905> <:Soulrune:536252660333019136>
@@ -183,8 +183,7 @@ Abyssal lords are by far the best abyssal creatures task for both exp and gp. Du
 .
 ⬥ Use a Blood Reaver <:reaverpouch:839903693837959228> familiar and pray Soul Split <:soulsplit:615613924506599497>.
 
-⬥ Use Vampyrism aura <:vamp:643505653079343144> if using Achto armour <:achtoprimevalhelm:641346213316395019> instead of Cryptbloom armour <:cryptbloomhelm:892819107123195956>
-    • This is due to Achto not providing % damage reduction for magic damage.
+⬥ Vampyrism aura <:vamp:643505653079343144> is preferred as it provides more kills per hour and safety (especially if using Achto armour <:achtoprimevalhelm:641346213316395019> instead of Cryptbloom armour <:cryptbloomhelm:892819107123195956>, as it does not providing % damage reduction for magic damage).
 
 .
 **__Revo bars__**


### PR DESCRIPTION
Updated the abyssal lords section to highlight that vamp aura is preferred over Runic as it provides more KPH (because of the high poison synergy with blood reaver, SS, wep+++, chain, magma, cannon...), despite the small loss in accuracy.