### PR TITLE
Pthentraken Disclaimer: "is has" -> "has"

### DIFF
--- a/mid-tier-pvm/rex-matriarchs.txt
+++ b/mid-tier-pvm/rex-matriarchs.txt
@@ -218,7 +218,7 @@ Use a revolution bar with a primary focus on channelled abilities as they are le
 .tag:afkpthen
 .
 __**Disclaimer**__
-This AFK method is has high requirements regarding **equipment** and **unlocked abilities + passive effects.**
+This AFK method has high requirements regarding **equipment** and **unlocked abilities + passive effects.**
 
 ⬥ The gear setups used represent the **minimum requirements** (or close) to reliably attain the advertised KPH while being consistently safe.
 


### PR DESCRIPTION
Fixes a small typo where the first sentence under the Pthentraken disclaimer says "is has" instead of "has"; Line 221.