### PR TITLE
Update wilderness-slayer.txt

### DIFF
--- a/slayer/wilderness-slayer.txt
+++ b/slayer/wilderness-slayer.txt
@@ -213,10 +213,6 @@ Lava Strykewyrms are one of the most profitable slayer tasks, while also providi
 ⬥ **Death Note** - automatically notes dropped bones and ashes. May be used if the player hasn't yet completed the Elite Wilderness Achievements.
 
 .
-⬥ **Death Ward** <:deathward:697808774068699286> - 5% damage reduction when your life points are below 50%; 10% damage reduction when they are below 25%
-    • This can be useful to aid the player's survivability, but is by no means a requirement.
-
-.
 > **__Method__**
 
 After the Wilderness Update, killing Lava Strykewyrms has become substantially safer. Despite that, their drops are still highly valued because the uniques are quite rare and the Searing Ashes are in high demand as they are the main ingredient for Aggresion Potions.


### PR DESCRIPTION
Removed Death Ward relic from useful items in the lava strykewyrms section as it is by no means required, since they are extremely safe to kill