### PR TITLE
updates to editor resources

### DIFF
--- a/guide-writing/ability-bar-builder.txt
+++ b/guide-writing/ability-bar-builder.txt
@@ -1,0 +1,41 @@
+.
+> __**Introduction**__
+.tag:intro
+⬥ Some guides require sharing an action bar to go with them, but it can be difficult to make in-game if you don't have spare action bars, or if you don't have the required abilities to do so unlocked.
+⬥ A couple tools have been developed that make this process easier.
+
+.
+> __**Ability Bar Builder**__
+.tag:abilitybarbuilder
+⬥ Try it here: **<https://nullopt.github.io/ability-bar-builder/>**
+.img:https://i.imgur.com/jo4cP2j.png
+⬥ This tool was created by <@102870112314335232> allows you to quickly create custom revolution bars that you can then take screenshots of, or directly export as `.png` files for use in guides.
+⬥ To use it, **simply click on an ability bar slot to choose an ability to populate it**.
+⬥ You can use the toggles above to change the bar length, toggle the yellow outline on/off, and remove the white number icons.
+
+.
+> __**Revo Bar Tool**__
+.tag:revobartool
+⬥ Try it here: **<http://rs-revolution.herokuapp.com/bar/>**
+.img:https://i.imgur.com/50aZhme.png
+⬥ This tool was created by <@335084211067289601> and allows you to create custom revolution bars, similar to the **Ability Bar Builder.**
+⬥ To use it, **drag and drop abilities from the menus above into the bar**. To clear a slot on the bar, simply drag out the ability from it.
+⬥ You can also simulate using the revolution bar in combat, to compare its long-term sustained DPS with other bars.
+⬥ Note that this tool may sometimes be down (towards the end of a month), due to excessive traffic.
+
+.
+{
+  "embed": {
+    "title": "Table of Contents",
+    "color": 39423,
+    "fields": [
+      {
+        "name": "__Information__",
+        "value": "⬥ [Introduction]($linkmsg_intro$)\n⬥ [Ability Bar Builder]($linkmsg_abilitybarbuilder$)\n⬥ [Revo Bar Tool]($linkmsg_revobartool$)",
+        "inline": true
+      }
+    ]
+  }
+}
+.embed:json
+.pin:delete

--- a/guide-writing/preset-generator.txt
+++ b/guide-writing/preset-generator.txt
@@ -1,0 +1,87 @@
+.
+> __**Introduction**__
+.tag:intro
+The **PVMe Preset Generator**, developed by <@!207588233780002818>, is a Google Sheet created for the purpose of making standarised presets for guides easier to create and maintain. It is the preferred way to display presets in guides.
+
+**This guide only covers how to use the tool. For full preset formatting, please see <#1020843999642271774> or any of the other guides in PVMe where presets are used.**
+
+The preset generator can be found at the following link.
+.
+{
+  "embed": {
+    "color": 39423,
+    "fields": [
+      {
+        "name": "__Preset Generator__",
+        "value": "Check out the PVME Preset Generator [here](https://docs.google.com/spreadsheets/d/1WpbEGSWK5qhsdq7ERMYh70PUOg9BTW85nFW0TAcNWCQ).\n__Make a copy__ to use for yourself."
+      }
+    ]
+  }
+}
+.embed:json
+
+.
+> __**Preset Generator Layout**__
+.tag:layout
+⬥ When you open the preset generator, you'll see the following layout.
+.img:https://i.imgur.com/7yZxYbS.png
+⬥ There are **4 sheets** shown at the bottom.
+⬥ **Presets Sheet**
+    • Contains the final output preset images.
+⬥ **Presets - Source**
+    • Contains the populated names for the items in the presets.
+    • This is how you decide what items are shown in the presets.
+⬥ **Presets - Item Database**
+    • Contains the raw information required by the preset generator to function.
+⬥ **Presets - Breakdown**
+    • Contains the full breakdowns (item names + additional info/comments) for presets.
+
+.
+> __**Creating a Preset**__
+.tag:guide
+__**Step 1: Populating Preset**__
+⬥ The first step is to fill the preset contents.
+⬥ Go to the *Presets - Source* sheet and find find the cells associated with your preset. You will see something like the following:
+.img:https://i.imgur.com/SiQBFRG.png
+⬥ **You need to write the appropriate item names in the cells to create the preset.**
+⬥ Item names are available in the dropdown menu as you type, but you can also find them in the *Presets - Item Database* tab.
+    • This process will become faster as you learn the item names as you create more presets.
+
+.
+__**Step 2: Populating Preset Breakdown**__
+⬥ The second step is to populate the advanced preset breakdown.
+⬥ Go to the *Presets - Breakdown* sheet and find the cells associated with your preset. You will see something like the following:
+.img:https://i.imgur.com/c8OiFru.png
+⬥ **You need to fill in any notes required to make the breakdown more useful for viewers**. The purpose of the breakdown is for readers who are not sure what items are in a preset in a guide, and so any additional comments here can be useful. See the following for an example of a filled-in breakdown.
+.img:https://i.imgur.com/0hpAL3h.png
+
+.
+__**Step 3: Taking Screenshots**__
+⬥ The third step is to take screenshots of your preset and its breakdown.
+⬥ **For the preset screenshot**:
+    • Zoom in your browser tab to **150%**.
+    • Capture the preset with a small border around the items.
+    • See the following example of an example of a properly taken preset image:
+.img:https://i.imgur.com/P28zwFP.png
+.
+⬥ **For the preset breakdown screenshot**:
+    • Zoom out your browser to 90% (on a standard 1080p screen, this is sufficient).
+    • Capture the preset breakdown, staying within the white/grey border.
+    • The image should be a single, unbroken image.
+
+.
+{
+  "embed": {
+    "title": "Table of Contents",
+    "color": 39423,
+    "fields": [
+      {
+        "name": "__Information__",
+        "value": "⬥ [Introduction]($linkmsg_intro$)\n⬥ [Preset Generator Layout]($linkmsg_layout$)\n⬥ [Creating Preset - Guide]($linkmsg_guide$)",
+        "inline": true
+      }
+    ]
+  }
+}
+.embed:json
+.pin:delete

--- a/guide-writing/rotation-builder.txt
+++ b/guide-writing/rotation-builder.txt
@@ -1,7 +1,49 @@
-<@!207588233780002818> made a rotation builder website (https://pvme.github.io/rotation-builder/) that will display pictures of the emojis when you type their name or an alias of their name from <#1020845621227307110>. For example if i type gbarge -> assault -> deci -> destroy, it will give me greaterbarge → assault → decimate → destroy, it outputs this:
+.
+> __**Introduction**__
+.tag:intro
+⬥ The **Rotation Builder** is a tool that was developed by <@207588233780002818> to make writing rotations for guides easier.
+⬥ Try it for yourself here: **<https://pvme.github.io/rotation-builder/>**
+
+.
+> __**Rotation Builder Layout**__
+.tag:layout
+⬥ When you open the website you'll see the a layout similar to the following.
+.img:https://i.imgur.com/bigtPP9.png
+⬥ **Input Text** is where your input text goes.
+⬥ **Output** is a live output of the emojis from your input text.
+⬥ **Copy Options** allow you to copy the text in a couple different output options.
+    • **Copy Discord** copies the text as it would be input for a guide in PVME.
+    • **Copy Draw.io** copies the raw HTML for import into **draw.io** (a free online tool that helps make flowcharts, diagrams, etc.)
+
+.
+> __**Input Text**__
+.tag:input
+⬥ When typing the name or alias of an emoji from <#1020845621227307110>, the website will automatically display it as an emoji instead of text.
+⬥ For example, typing the raw input text `gbarge → assault → deci → destroy` will yield the following output:
 .img:https://i.imgur.com/7x5KPtM.png
-⬥ Instructions to use the rotation builder are on the website, but feel free to ask questions if you need help.
+⬥ More examples of how to format input are given on the website.
 
-⬥ When you make a new rotation, please cope paste your INPUT text into the <#924678625465368656> channel of github, or paste it in <#724129126314803230> and ask someone to post it to github for you. We Want to save the input text so we have something to go back if the rotation requires edits in the future.
+.
+> __**Saving Output**__
+.tag:output
+⬥ **To save it as an image**: please screenshot *only* the output section.
+    • A picture of the rotation looks cleaner and is more easily shared with people than a ton of emoji text IDs.
+⬥ **To use emojis directly in a guide**: use the **Copy Discord** button and paste the copied text into your guide.
+⬥ Copying the data for draw.io: follow the tutorial given at the bottom of the website.
 
-⬥ When you are happy with how the rotation looks, please screenshot just the OUTPUT section and use the screenshot of the rotation for the actual guide. A picture of the rotation looks cleaner and is more easily shared with people than a ton of emoji text IDs.
+.
+{
+  "embed": {
+    "title": "Table of Contents",
+    "color": 39423,
+    "fields": [
+      {
+        "name": "__Information__",
+        "value": "⬥ [Introduction]($linkmsg_intro$)\n⬥ [Layout]($linkmsg_layout$)\n⬥ [Input Text]($linkmsg_input$)\n⬥ [Saving Output]($linkmsg_output$)",
+        "inline": true
+      }
+    ]
+  }
+}
+.embed:json
+.pin:delete

--- a/guide-writing/website-editor-tool.txt
+++ b/guide-writing/website-editor-tool.txt
@@ -1,52 +1,85 @@
-<https://pvme.github.io/guide-editor/> by <@!207588233780002818>: A comprehensive editor tool to accelerate guide making for PvME.
+.
+> __**Introduction**__
+.tag:intro
+⬥ Try it for yourself: **<https://pvme.github.io/guide-editor/>**
+⬥ The **PVME Guide Editor**, developed by <@!207588233780002818>, is a comprehensive editor tool to accelerate guide making for PvME.
+⬥ It is the recommended way to write content for guides, as it makes it easier to write guides with the live preview, and prevent issues from occuring when submitting them with the help of the integrated error checker.
 
 .
-When you open the website you'll see 3 boxes with a top bar.
-.
-.img:https://imgur.com/bXI7tuj.png
-.
-**Box 1** is where you put your text.
-**Box 2** is live preview of what it will look like in discord.
-**Box 3** displays any formatting errors in your text.
+> __**Editor Layout**__
+.tag:layout
+⬥ When you open the website you'll see the a layout similar to the following.
+.img:https://i.imgur.com/zr62id2.png
+⬥ **Input Text** is where your input text goes.
+⬥ **Discord Preview** is a live preview of what it will look like in discord.
+⬥ **Error Checker** displays any formatting and syntax errors in your text that need to be corrected.
+⬥ The **Formatting Bar** contains tools to help you format your input text.
+    • Covered in detail below.
 
 .
-**Top Bar** buttons from left to right:
+> __**Formatting Bar**__
+⬥ The formatting bar at the top contains tools to help format your input text.
 .
+__**Text Formatting**__
 .img:https://imgur.com/WcekSyf.png
-.
-**B** *I* __U__ ~~S~~ - **Bold**, *italicize*, __underline__, and ~~strike through~~.
-**H1** - Indents, bolds and underlines paragraph.
-**H2** - Bolds and underlines paragraph.
+⬥ **B** *I* __U__ ~~S~~ - **Bold**, *italicize*, __underline__, and ~~strike through~~.
+⬥ **H1** - Indents, bolds and underlines paragraph.
+⬥ **H2** - Bolds and underlines paragraph.
 
 .
+__**Lists and Code**__
 .img:https://imgur.com/H8jz5KQ.png
-**2 buttons on the left** - Reformats selected text as bulleted and numbered lists, respectively.
-**2 buttons on the right** - Applies the following effects to selected words:
-.
+⬥ **2 buttons on the left** - Reformats selected text as **bulleted** and **numbered** lists, respectively.
+⬥ **2 buttons on the right** - Reformat selected text as **inline code** and as a **code block** respectively.
 .img:https://imgur.com/HUYXf3K.png
 
 .
+__**Commands and Templates**__
 .img:https://imgur.com/YpdbuKa.png
-Template ⏷ - Dropdown containing a few short stylistic templates to be standardized across editors creating guides (e.g. adding website links, describing EoFs and Rune Pouch contents).
+⬥ **Template ⏷** - Menu containing a few short stylistic templates to be standardized across editors creating guides. This will be updated as new templates get added.
+    • Contains templates for embeds, a barebones guide template, a copy of the style guide for reference, etc.
+⬥ **Command ⏷** - Menu containg a few shortcuts for implementing elements other than raw text (e.g. images, tags for Table of Contents, links to spreadsheet values, etc.).
 
 .
-⬥ This is the most notable button convenience wise, allowing you to use functions like "Embed Formatting" for a complete raw template of an embed, or "Guide" for a complete raw backbone of an entire guide.
-
-Command ⏷ - Dropdown containg a few shortcuts for implementing elements other than raw text (e.g. images, tags (for TOC), and links to spreadsheet values).
-
-.
+__**Misc. Buttons**__
 .img:https://imgur.com/rYEb2gj.png
 .
-<|> - Toggles automatically scrolling of the live preview to the bottom of the preview (mimics guide channels in the discord).
-
-👁 - Toggles the live preview on/off, useful for reducing lag if writing very long guides.
-
-.
-? - Shows various autoformatting shortcuts for features like emojis, channel names, role names, and users, which automatically becomes converted into the proper discord text.
-
-ⓘ - Links websites editors may use, as well as the issues tab for this website editor for any updates that are in the works.
+⬥ **<|>** - Toggles automatically scrolling of the live preview to the bottom of the preview (mimics guide channels in the discord).
+⬥ **👁** - Toggles the live preview on/off, useful for reducing lag when writing very long guides.
+⬥ **?** - Shows formatting shortcuts and features, and instructions for the editor.
+⬥ ⓘ - Some quick links for editors may use, as well as the GitHub issues tab for this website editor for any updates that are in the works.
 
 .
-Video walkthrough by <@160462420693745664>: https://youtu.be/LQWuufctPLA
+> __**Input Text**__
+.tag:input
+⬥ Use the **left box for input text** to write the raw content for your guides.
+⬥ There is a **live preview on the right**, as shown in the layout image above.
+⬥ See the question mark **?** button on the top right of the web editor for tips to make editing a little quicker.
 
 .
+> __**Error Checker**__
+.tag:error
+⬥ If any style or formatting errors are present in your guide, then they will be listed here.
+⬥ The checker is the same as the one used during pull requests on GitHub, so **if you see any errors here, fix them before submitting it!**
+
+.
+> __**Video Tutorial**__
+.tag:video
+If you prefer to watch a video guide, then see the following tutorial by <@160462420693745664>: https://youtu.be/LQWuufctPLA
+
+.
+{
+  "embed": {
+    "title": "Table of Contents",
+    "color": 39423,
+    "fields": [
+      {
+        "name": "__Information__",
+        "value": "⬥ [Introduction]($linkmsg_intro$)\n⬥ [Editor Layout]($linkmsg_layout$)\n⬥ [Input Text]($linkmsg_input$)\n⬥ [Error Checker]($linkmsg_error$)\n⬥ [Video Tutorial]($linkmsg_video$)",
+        "inline": true
+      }
+    ]
+  }
+}
+.embed:json
+.pin:delete


### PR DESCRIPTION
Changes:
- added preset generator tool info
- added ability bar builder tool info
- updated rotation builder tool and web editor tool contents

If we plan to continue using forum posts in editor-resources category:
- Please create 2 forum posts in the **editor-tools** forum and link the preset generator and ability bar builder.
- Also: the forum post **editor-quick-start** should be moved out and made into a regular channel by itself like **#requests**, as it's supposed to be a quick start for links/etc. so it should be the first thing in the category and easy to click like a normal channel.
- Also: maybe the forum **editor-tutorials** should probably have its name updated to **GitHub** since there's only like two guides and they're both for GitHub.
- Updated structure **(please check file-to-channel links and update them with bot as needed)**
```
Cat: Editor Resources
    Ch: Editor Quick Start
    Ch: Requests
    F: Editor Tools
        Fp: Guide Editor
        Fp: Rotation Builder
        Fp: Ability Bar Builder
        Fp: Preset Generator
    F: Editor References
        Fp: Templates
        Fp: Emoji List
        Fp: Style Guide
    F: GitHub
        Fp: GitHub Tutorial
        Fp: GitHub Tips and Tricks

```
Once this PR and the above channel changes are done, I'll go through the channels and update some info and links (mostly **editor-quick-start**).