### PR TITLE
enh: add !hitchance reference to damage troubleshoot command

### DIFF
--- a/commands/damagetroubleshoot.txt
+++ b/commands/damagetroubleshoot.txt
@@ -16,7 +16,7 @@
       },
 	  {
         "name": "__Other__",
-        "value": "⬥ Using an Overload <:elderovl:841419289831800882>?\n⬥ Vulnerability <:Vuln:537349530551582720> / <:vulnbomb:655341074235129858>?\n⬥ Using `!familiar`?\n⬥ If poisonable, `!poison`?\n⬥ Using lossless foods?\n\u00a0\u00a0\u00a0\u00a0• E.g. <:grest:689530593901412578> / <:blueblubber:689530593742291033>\n⬥ Correct prayer active?",
+        "value": "⬥ Using an Overload <:elderovl:841419289831800882>?\n⬥ Vulnerability <:Vuln:537349530551582720> / <:vulnbomb:655341074235129858>?\n⬥ Using `!familiar`?\n⬥ If poisonable, `!poison`?\n⬥ Using lossless foods?\n\u00a0\u00a0\u00a0\u00a0• E.g. <:grest:689530593901412578> / <:blueblubber:689530593742291033>\n⬥ Correct prayer active?\n⬥ `!hitchance` is 100%?",
         "inline": true
       }
     ]

--- a/commands/hitchance.txt
+++ b/commands/hitchance.txt
@@ -5,6 +5,10 @@
     "color": 4681819,
     "fields": [
       {
+        "name": "__Why it matters__",
+        "value": "Being <100% hitchance results in a large DPS loss due to splashing."
+      },
+      {
         "name": "__Important__",
         "value": "Sign in to Google Sheets to **make an editable copy** of the sheet."
       },


### PR DESCRIPTION
This also adds a "Why it matters" field to the `!hitchance` command.