### PR TITLE
Typo fix in ultimate-slayer.txt

### DIFF
--- a/slayer/ultimate-slayer.txt
+++ b/slayer/ultimate-slayer.txt
@@ -151,9 +151,6 @@ This method is focused on rolling the slayer choice perk. This is achieved with 
 .
 **__Useful spreadsheets__**
 
-.
-**__Useful spreadsheets__**
-
 .tag:sheets
 {
   "embed": {


### PR DESCRIPTION
Removed extra "Useful spreadsheets" subheading.