### PR TITLE
Typo fixes in perks.txt

### DIFF
--- a/invention-and-perks/perks.txt
+++ b/invention-and-perks/perks.txt
@@ -307,7 +307,7 @@ __**Enhanced Devoted**__ <:enhdev4:712073087507628035>
 .
 **__Turtling__** <:turtling4:712073737377284146>
 .tag:tu
-⬥ **Turtling 4:** `(1/2.37 at 137 invention)` 3 <:evasivecomp:643829647049752586> 6 <:historiccomps:697405254676906018> <:coins:698816156961603654> $data_pvme:Perks!H9$
+⬥ **Turtling 4:** 3 <:evasivecomp:643829647049752586> 6 <:historiccomps:697405254676906018> `(1/2.37 at 137 invention)` <:coins:698816156961603654> $data_pvme:Perks!H9$
 ⬥ **Turtling 4 Ultimatums 4:** 9 <:historiccomps:697405254676906018> `(1/19.1 at 137 invention)` <:coins:698816156961603654> $data_pvme:Perks!H10$
 ⬥ **Turtling 4 Mobile:** 7 <:historiccomps:697405254676906018> 1 <:dextrouscomp:607288026263191563> 1 <:subtlecomp:607288026305134608> `(1/659 at 90/91 invention)` <:coins:698816156961603654> $data_pvme:Perks!H77$
 ⬥ **Turtling 3 Taunting:** 2 <:knightlycomp:583435544315559977> 1 <:historiccomps:697405254676906018> 6 <:evasivecomp:643829647049752586> `(1/7.53 at 137 invention)` <:coins:698816156961603654> $data_pvme:Perks!H87$


### PR DESCRIPTION
Removed an unnecessary '+` from the Impatient 4/Reflexes combo and an extra i from the Invigorating subsection title.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
