### PR TITLE
Update style-guide.txt swapped formatting lists image to code block

### DIFF
--- a/editor-resources/editor-references/style-guide.txt
+++ b/editor-resources/editor-references/style-guide.txt
@@ -129,7 +129,15 @@ __**Alphanumerical Lists**__
         ⬩ Format subsubpoints like this:  `⬩` indented by 8 spaces.
     b. __**Bold and underline lists if they ever act as titles**__.
 .
-.img:https://img.pvme.io/images/qmLCbAE.png
+```
+⬥ Main point
+    • Subpoint describing main point
+        ⬩ Sub-subpoint describing subpoint in further detail
+
+1. Main point
+    a. Subpoint describing main point
+        ⬩ Sub-subpoint describing subpoint in further detail
+```
 .
 ⬥ The above example shows examples of formatted lists within a file.
 ⬥ **Use subpoints and sub-subpoints as required to avoid illegible walls of text**. Ideally, keep text as consise as it can be without losing meaning or readability.


### PR DESCRIPTION
-As per suggestion, the image showcasing the current format used to for lists was updated from an image, to a code block -Sub-subpoints are now: ⬩, not -

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
