### PR TITLE
update necro telos with conjure army, p4 drop rot, note on surge/bd b…

### DIFF
--- a/rs3-full-boss-guides/telos/necromancy.txt
+++ b/rs3-full-boss-guides/telos/necromancy.txt
@@ -48,10 +48,11 @@ Pre-building stacks at wars is **recommended** as it allows you to achieve more 
 
 If wanting safer P1's, use <:devo:513190158728953857> before surge, however for faster P1's use <:commandskeleton:1137809194423160883>
 
-<:conjureskeleton:1159434516658651147> → <:conjureghost:1137809206423060632> → <:conjurezombie:1137809200219684924> → <:commandghost:1159434409913634816> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → <:commandskeleton:1137809194423160883> / <:limitless:641339233638023179> <:devo:513190158728953857> → (wait 2 ticks) → <:surge:535533810004262912>
+<:conjurearmy:1166094935066423348> → <:invokedeath:1137809121983336548> → <:commandghost:1159434409913634816> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → (wait 2 ticks) → <:surge:535533810004262912> → <:commandskeleton:1137809194423160883> / <:limitless:641339233638023179> <:devo:513190158728953857>
 .
 > **__Phase 1__**
 .
+Note: To better line up conjure and <:livingdeath:1159434908486357072> durations you must <:surge:535533810004262912> / <:bd:535532854281764884> to the drop spot in each phase
 <:ingen:641339234111848463> <:praeswand:643166769518739477> tc <:smokecloud:856635090641879050> <:omniguard:1138809234922934282> <:touchofdeath:1137809175980810380> → <:deathskulls:1159434663903899728> → <:fingerofdeath:1159434801938432010> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> → <:necroauto:1137809137401602109> → <:soulsap:1137809140476031057> → <:fingerofdeath:1159434801938432010>
 .
 .
@@ -69,11 +70,11 @@ Note: For information on how to use sticky bombs in p4 for minions effectively p
 .
 **__Drop__**
 .
-<:fingerofdeath:1159434801938432010> → <:deathguard90:1138809243143766118> <:eofspec:746403211908481184>
+<:omniguard:1138809234922934282> <:spec:537340400273195028> → <:deathguard90:1138809243143766118> <:eofspec:746403211908481184>
 .
 **__Font 1__**
 .
-<:res:535541258844635148> → <:reflect:535541258786177064> → <:anticlearheaded:867678154071998464> → <:prep:535541258546970624> → <:invokedeath:1137809121983336548> → <:volleyofsouls:1159435029592686642> → <:fingerofdeath:1159434801938432010>
+<:res:535541258844635148> → <:reflect:535541258786177064> → <:anticlearheaded:867678154071998464> → <:prep:535541258546970624> → <:necroauto:1137809137401602109> → <:volleyofsouls:1159435029592686642> → <:fingerofdeath:1159434801938432010>
 .
 **__Font 2__**
 .


### PR DESCRIPTION
…etween phases

NOTE: This is not a fully updated rot just an addition with the QOL from conjure army (I have not added life xfer as it wasn't originally present in rot) and correcting the surge timing for prebuild; as well as noting that you will need to surge/bd to correct spot at the end of each phase or else your conjures / LD will expire far too early to follow rot. Also updated the p4 drop rot to the more consistent t95 spec -> t90 eof

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
