### PR TITLE
Fix broken link in clans command and teamforming command

### DIFF
--- a/commands/clans.txt
+++ b/commands/clans.txt
@@ -1,7 +1,7 @@
 {
   "embed": {
     "title": "__Finding a PvM Clan__",
-    "description": "You can check either [RS Forums PvM Clans](https://secure.runescape.com/m=forum/forums?92,93) or [RS3 Discord Clan Channel](https://discord.gg/pvmcity).\nFor PvM teamforming discords, refer to `!7`",
+    "description": "You can check either [RS Forums PvM Clans](https://secure.runescape.com/m=forum/forums?92,93) or the [Official Runescape Discord](https://discord.gg/rs)\nFor PvM teamforming discords, refer to `!7`",
     "color": 39423
   }
 }

--- a/commands/teamforming.txt
+++ b/commands/teamforming.txt
@@ -16,7 +16,7 @@
             },
             {
                 "name": "**__Finding PvM Clans__**",
-                "value": "[RS Forums PvM Clans](https://secure.runescape.com/m=forum/forums?92,93)\n[RS3 Discord Clan Channel](https://discord.gg/pvmcity)",
+                "value": "[RS Forums PvM Clans](https://secure.runescape.com/m=forum/forums?92,93)\n[Official Runescape Discord](https://discord.gg/rs)",
                 "inline": true
             }
         ]


### PR DESCRIPTION
-The PvM City link to find clans was broken, for both commands
-Linked the official Runescape Discord instead as they have a few channels for finding clans, and are more active

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
