### PR TITLE
Solak necromancy-solo: added targeting info and missing threads

### DIFF
--- a/rs3-full-boss-guides/solak/necromancy-solo.txt
+++ b/rs3-full-boss-guides/solak/necromancy-solo.txt
@@ -55,7 +55,7 @@ After <:livingdeath:1159434908486357072> ends, clear remaining rootlings with <:
 
 .
 __Arms:__
-(tc) solak main body → <:volleyofsouls:1159435029592686642> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> → <:soulsap:1137809140476031057> + move under solak +<:vulnbomb:655341074235129858> (targeted, see vid).
+Target Solak's main body (targeted <:vulnbomb:655341074235129858> helps, or tc multiple times) → <:threadsoffate:1137809172335951933> → <:volleyofsouls:1159435029592686642> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> → <:soulsap:1137809140476031057> + move under solak +<:vulnbomb:655341074235129858> (targeted, see vid).
 
 __Legs:__
 (tc) left leg <:splitsoul:1137809168368148490> → <:spectralscythe:1137809145706319892> → <:spectralscythe2:1137809149690916945> → <:spectralscythe3:1137809152043925505> → <:lifetransfer:1137809128136388819> → filler (<:soulsap:1137809140476031057>/<:touchofdeath:1137809175980810380> ) → <:invokedeath:1137809121983336548>


### PR DESCRIPTION
- How to target Solak when arms are already up.
- Threads of fate was missing from arms rotation.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
