### PR TITLE
Update afk-zilly: necro method is broken and removed

### DIFF
--- a/afk/afk-commander-zilyana.txt
+++ b/afk/afk-commander-zilyana.txt
@@ -16,7 +16,7 @@
     • Only needed if using Magic <:magic:689504724159823906>
 
 .
-> **__Magic AFK Method (~47-50 kph)__** <:magic:689504724159823906>
+> **__Magic AFK Method (50+ kph)__** <:magic:689504724159823906>
 .tag:mageAFK
 **__Overview__**
 .
@@ -28,15 +28,15 @@
     "fields": [
       {
         "name": "__Items__",
-        "value": "⬥ [Essence of Finality](https://runescape.wiki/w/Essence_of_Finality_amulet) <:eof:787526151978614824>\n⬥ [Scripture of Wen](https://runescape.wiki/w/Scripture_of_Wen) <:scriptureofwen:883134307902816297>\n\u00a0\u00a0\u00a0\u00a0• Can be replaced with <:elementsscrim:841409588959510539>\n⬥ A full set of [Cryptbloom armour](https://runescape.wiki/w/Cryptbloom_armour) <:cryptbloomhelm:892819107123195956>\n\u00a0\u00a0\u00a0\u00a0• The fungal shield can help survive instances of high damage"
+        "value": "⬥ [Essence of Finality](<https://runescape.wiki/w/Essence_of_Finality_amulet>) <:eof:787526151978614824>\n⬥ [Scripture of Wen](<https://runescape.wiki/w/Scripture_of_Wen>) <:scriptureofwen:883134307902816297>\n\u00a0\u00a0\u00a0\u00a0• Can be replaced with <:elementsscrim:841409588959510539>\n⬥ A full set of [Cryptbloom armour](<https://runescape.wiki/w/Cryptbloom_armour>) <:cryptbloomhelm:892819107123195956>\n\u00a0\u00a0\u00a0\u00a0• The fungal shield can help survive instances of high damage"
       },
       {
         "name": "__Abilities__",
-        "value": "⬥ [Greater Concentrated Blast](https://runescape.wiki/w/Greater_Concentrated_Blast) <:gconc:869285393223254107>\n⬥ [Greater Chain](https://runescape.wiki/w/Greater_Chain) <:gchain:787904334495088672>\n⬥ [Greater Sunshine](https://runescape.wiki/w/Greater_Sunshine) <:gsunshine:994644352871714836>"
+        "value": "⬥ [Greater Concentrated Blast](<https://runescape.wiki/w/Greater_Concentrated_Blast>) <:gconc:869285393223254107>\n⬥ [Greater Chain](<https://runescape.wiki/w/Greater_Chain>) <:gchain:787904334495088672>\n⬥ [Greater Sunshine](<https://runescape.wiki/w/Greater_Sunshine>) <:gsunshine:994644352871714836>"
       },
       {
         "name": "__Other__",
-        "value": "⬥ [Exsanguinate](https://runescape.wiki/w/Exsanguinate) <:exsanguinate:856635090745950258>\n⬥ [Animate Dead](https://runescape.wiki/w/Animate_Dead) <:animatedead:856635090453135382>\n⬥ [Hellhound](https://runescape.wiki/w/Hellhound_(familiar)) <:hellhoundpouch:921410226475925514> with [Soul Food scrolls](https://runescape.wiki/w/Hellhound_scroll_(Soul_Food)) <:hellhoundscroll:922417969731088435>\n\u00a0\u00a0\u00a0\u00a0• Will occasionally need to manually cast special attack to heal familiar\n⬥ [Prism of Restoration](https://runescape.wiki/w/Prism_of_Restoration) <:prismofrestoration:938475261366784070>\n\u00a0\u00a0\u00a0\u00a0• Used at least every 5 minutes to heal your [Hellhound](https://runescape.wiki/w/Hellhound_(familiar)) <:hellhoundpouch:921410226475925514>"
+        "value": "⬥ [Exsanguinate](<https://runescape.wiki/w/Exsanguinate>) <:exsanguinate:856635090745950258>\n⬥ [Animate Dead](<https://runescape.wiki/w/Animate_Dead>) <:animatedead:856635090453135382>\n⬥ [Hellhound](<https://runescape.wiki/w/Hellhound_(familiar)>) <:hellhoundpouch:921410226475925514> with [Soul Food scrolls](<https://runescape.wiki/w/Hellhound_scroll_(Soul_Food)>) <:hellhoundscroll:922417969731088435>\n\u00a0\u00a0\u00a0\u00a0• Will occasionally need to manually cast special attack to heal familiar\n⬥ [Prism of Restoration](<https://runescape.wiki/w/Prism_of_Restoration>) <:prismofrestoration:938475261366784070>\n\u00a0\u00a0\u00a0\u00a0• Used at least every 5 minutes to heal your [Hellhound](<https://runescape.wiki/w/Hellhound_(familiar)>) <:hellhoundpouch:921410226475925514>"
       }
     ]
    }
@@ -73,70 +73,14 @@
 .
 **__Example Kills__** <:magic:689504724159823906>
 .
-⬥ [Magic](https://youtu.be/kmk0NvPWRNI)
-.
-
-.
-> **__Necromancy AFK Method (~40kph)__** <:necromancy:1148995625896120460>
-.tag:necroAFK
-**__Overview__**
-.
-{
-  "embed": {
-  "title": "__Mandatory AFK Requirements__",
-    "description":"⬥ The following **ARE REQUIRED** for this method to work:\n\u00a0\u00a0\u00a0\u00a0• **Cutting corners will result in failure**\n\u00a0\u00a0\u00a0\u00a0• A more extensive list can be found in <#1130180182544744551>",
-    "color": 39423,
-    "fields": [
-      {
-        "name": "__Talent Tree Unlocks__",
-        "value": "⬥ Tiers 1-2\n\u00a0\u00a0\u00a0\u00a0• [Conjure Skeleton Warrior](https://runescape.wiki/w/Conjure_Skeleton_Warrior) <:conjureskeleton:1159434516658651147> and [Command Skeleton Warrior](https://runescape.wiki/w/Command_Skeleton_Warrior) <:commandskeleton:1137809194423160883>\n⬥ Tiers 3-4\n\u00a0\u00a0\u00a0\u00a0• [Conjure Vengeful Ghost](https://runescape.wiki/w/Conjure_Vengeful_Ghost) <:conjureghost:1137809206423060632> and [Command Vengeful Ghost](https://runescape.wiki/w/Command_Vengeful_Ghost) <:commandghost:1159434409913634816>"
-      },
-      {
-        "name": "__Other__",
-        "value": "⬥ [Darkness](https://runescape.wiki/w/Darkness) <:darkness:1137809209782698024>\n⬥ [Penance Aura](https://runescape.wiki/w/Penance_aura) <:penanceaura:643505653062565907>\n⬥ [Mobile Perk](https://runescape.wiki/w/Mobile) <:mob:689501908628799488>\n⬥ 3 pieces of [Deathdealer robe armour](https://runescape.wiki/w/Deathdealer_robe_armour#Tier_90)\n\u00a0\u00a0\u00a0\u00a0• Used to trigger passive Death Mark <:invokedeath:1137809121983336548> and skip the last 20k lp"
-      }
-    ]
-   }
-}
-.embed:json
-
-.
-**__Preset and Relics__** <:necromancy:1148995625896120460>
-.
-{
-  "embed": {
-    "title": "",
-    "color": 39423,
-    "image": {
-            "url": "https://img.pvme.io/images/Mj0E1L7VVs.png"
-        },
-    "fields": [
-      {
-        "name": "__Preset Suggestion & Breakdown__",
-        "value": "⬥ [Necromancy](https://pvme.io/preset-maker/#/raDBamwPmCuIF6fWIJ5t)",
-        "inline": true
-      }
-    ]
-  }
-}
-.embed:json
-⬥ Due to the risk of dying you may use a <:rod:513190159462825984> instead.
-
-.
-**__Ability Bar__** <:necromancy:1148995625896120460>
-.img:https://img.pvme.io/images/2lNjMRWYxy.png
-
-.
-**__Example Kills__** <:necromancy:1148995625896120460>
-.
-⬥ [Necromancy](https://www.youtube.com/watch?v=KeT7EndGmgo)
+⬥ [Magic](<https://youtu.be/kmk0NvPWRNI>)
 .
 
 .
 {
   "embed": {
     "title": "__Table of Contents__",
-    "description": "*To edit this guide, visit <id:customize> and select Entry Editor*\n⬥ [Disclaimer]($linkmsg_disclaimer$)\n⬥ [Positioning]($linkmsg_positioning$)\n⬥ [Magic AFK <:magic:689504724159823906>]($linkmsg_mageAFK$)\n⬥ [Necromancy AFK <:necromancy:1148995625896120460>]($linkmsg_necroAFK$)",
+    "description": "*To edit this guide, visit <id:customize> and select Entry Editor*\n⬥ [Disclaimer]($linkmsg_disclaimer$)\n⬥ [Positioning]($linkmsg_positioning$)\n⬥ [Magic AFK <:magic:689504724159823906>]($linkmsg_mageAFK$)",
     "color": 39423
     }
 }


### PR DESCRIPTION
Existing method kills you 4 times an hour while yielding 38-40kph. non-reaver set-ups work poorly due to death skulls needing to finish off zilly. Cannot reasonably compete with the magic method and is therefore scrapped.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
