### PR TITLE
Update necro-solo-solak: small fixes

### DIFF
--- a/rs3-full-boss-guides/solak/necromancy-solo.txt
+++ b/rs3-full-boss-guides/solak/necromancy-solo.txt
@@ -21,7 +21,7 @@ This is an advanced <:necromancy:1148995625896120460> guide to Grandmaster role 
     "fields": [
 {
         "name": "__Preset Suggestion & Breakdown__",
-        "value": "⬥ [Preset](https://pvme.github.io/preset-maker/#/8WB4Px7lt93AApDzxajC)",
+        "value": "⬥ [Preset](https://pvme.github.io/preset-maker/#/7pvg1MAQ6PiEv2mFjSXw)",
         "inline": true
       }
     ]
@@ -42,7 +42,7 @@ This is an advanced <:necromancy:1148995625896120460> guide to Grandmaster role 
 
 .
 __**Phase 1:**__
-(tc) + <:vulnbomb:655341074235129858> → <:deathskulls:1159434663903899728> → <:bloat:1159433682403201044> → <:soulsap:1137809140476031057> → <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → <:soulsap:1137809140476031057> (+run pad if close) → <:commandskeleton:1137809194423160883> → <:necroauto:1137809137401602109> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → <:touchofdeath:1137809175980810380> (run east to rootlings spawn) → <:deathskulls:1159434663903899728> (last two hits should hit rootlings) → <:necroauto:1137809137401602109> <:fingerofdeath:1159434801938432010> and <:deathskulls:1159434663903899728> off cooldown and <:touchofdeath:1137809175980810380> when off cd after <:deathskulls:1159434663903899728> (3x <:deathskulls:1159434663903899728> in <:livingdeath:1159434908486357072>) as you run solak to rootlings. One <:deathskulls:1159434663903899728> bounce + basic should kill rootling.
+(tc) + <:vulnbomb:655341074235129858> → <:deathskulls:1159434663903899728> → <:bloat:1159433682403201044> → <:soulsap:1137809140476031057> → <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → <:soulsap:1137809140476031057> (+run pad if close) → <:commandskeleton:1137809194423160883> → <:necroauto:1137809137401602109> → <:soulsap:1137809140476031057> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → <:touchofdeath:1137809175980810380> (run east to rootlings spawn) → <:deathskulls:1159434663903899728> (last two hits should hit rootlings) → <:necroauto:1137809137401602109> <:fingerofdeath:1159434801938432010> and <:deathskulls:1159434663903899728> off cooldown and <:touchofdeath:1137809175980810380> when off cd after <:deathskulls:1159434663903899728> (3x <:deathskulls:1159434663903899728> in <:livingdeath:1159434908486357072>) as you run solak to rootlings. One <:deathskulls:1159434663903899728> bounce + basic should kill rootling.
 
 After <:livingdeath:1159434908486357072> ends, clear remaining rootlings with <:soulsap:1137809140476031057> and <:necroauto:1137809137401602109>, you can do a 4th <:deathskulls:1159434663903899728> if solak still high hp or any rootlings alive.
 
@@ -61,28 +61,29 @@ __Legs:__
 (tc) left leg <:splitsoul:1137809168368148490> → <:spectralscythe:1137809145706319892> → <:spectralscythe2:1137809149690916945> → <:spectralscythe3:1137809152043925505> → <:lifetransfer:1137809128136388819> → filler (<:soulsap:1137809140476031057>/<:touchofdeath:1137809175980810380> ) → <:invokedeath:1137809121983336548>
 
 __Core:__
-(tc) core → <:bloat:1159433682403201044> (or <:soulsap:1137809140476031057> → <:bloat:1159433682403201044>) → <:commandskeleton:1137809194423160883> → <:volleyofsouls:1159435029592686642> → <:soulsap:1137809140476031057> → <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → filler to kill core → dismiss conjures + <:conjurearmy:1166094935066423348> → <:lifetransfer:1137809128136388819> → <:commandghost:1159434409913634816>
+(tc) core → <:bloat:1159433682403201044> (or <:soulsap:1137809140476031057> → <:bloat:1159433682403201044>) → <:commandskeleton:1137809194423160883> → <:volleyofsouls:1159435029592686642> → <:soulsap:1137809140476031057> → <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → filler to kill core → dismiss conjures + <:conjurearmy:1166094935066423348> → filler ability → <:commandghost:1159434409913634816>
 
 .
 __**Phase 2:**__
 __Eruptions:__
-southwest: <:soulsap:1137809140476031057> → <:flank4:712073088296157185><:soulstrike:1137809142376058910> → <:commandskeleton:1137809194423160883> + <:surge:535533810004262912> southeast → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> → <:flank4:712073088296157185><:soulstrike:1137809142376058910> + <:surge:535533810004262912> northeast → (have 8 <:necrosis:1139452791878856805>) <:deathguard90:1138809243143766118><:eofspec:746403211908481184> + <:dive:1049378668197195808> northwest → <:commandskeleton:1137809194423160883> → <:soulsap:1137809140476031057> → <:flank4:712073088296157185><:soulstrike:1137809142376058910>
+southwest: <:soulsap:1137809140476031057> → <:soulstrikeflank:1156683164593430579> → <:commandskeleton:1137809194423160883> + <:surge:535533810004262912> southeast → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> → <:soulstrikeflank:1156683164593430579> + <:surge:535533810004262912> northeast → (have 8 <:necrosis:1139452791878856805>) <:deathguard90:1138809243143766118><:eofspec:746403211908481184> + <:dive:1049378668197195808> northwest → <:commandskeleton:1137809194423160883> → <:soulsap:1137809140476031057> → <:soulstrikeflank:1156683164593430579>
 
 __Solak:__
 (tc) + <:vulnbomb:655341074235129858> → <:bloat:1159433682403201044> → <:commandzombie:1137809191231295549> → <:deathskulls:1159434663903899728> → <:conjurearmy:1166094935066423348> → <:lifetransfer:1137809128136388819> → <:commandghost:1159434409913634816> → <:commandskeleton:1137809194423160883> → <:praeswand:643166769518739477> (4tick) <:ingen:641339234111848463> + <:smokecloud:856635090641879050> + <:omniguard:1138809234922934282> → <:soulsap:1137809140476031057> → build to 100% → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → <:touchofdeath:1137809175980810380> → <:deathskulls:1159434663903899728> → <:soulsap:1137809140476031057> → <:splitsoul:1137809168368148490> → <:divert:787904334377648130> → <:soulsap:1137809140476031057> → <:bloat:1159433682403201044> → 5<:residualsoul:1139453152169558046> <:volleyofsouls:1159435029592686642> → <:livingdeath:1159434908486357072> rotation, use <:deathskulls:1159434663903899728> and keep <:bloat:1159433682403201044> active.
-post-<:livingdeath:1159434908486357072> use <:deathskulls:1159434663903899728> / <:volleyofsouls:1159435029592686642> / <:deathguard90:1138809243143766118><:eofspec:746403211908481184> / <:omniguard:1138809234922934282><:spec:537340400273195028> till phased.
+post-<:livingdeath:1159434908486357072>: use <:deathskulls:1159434663903899728> / <:volleyofsouls:1159435029592686642> / <:deathguard90:1138809243143766118><:eofspec:746403211908481184> / <:omniguard:1138809234922934282><:spec:537340400273195028> till phased.
 
 .
 __**Phase 3:**__
 Charge pad #1 + <:omniguard:1138809234922934282><:spec:537340400273195028> (if available) → build to 3 <:residualsoul:1139453152169558046> and <:bloat:1159433682403201044> → <:commandzombie:1137809191231295549> at 4s timer →  <:conjurearmy:1166094935066423348>
-Solak down → <:splitsoul:1137809168368148490> → <:flank4:712073088296157185><:soulstrike:1137809142376058910> → <:flank4:712073088296157185><:soulstrike:1137809142376058910> → <:flank4:712073088296157185><:soulstrike:1137809142376058910>.
-Charge pad #2 (preferably <500k lp Solak) → <:anti:535541306475151390> → build 3 <:residualsoul:1139453152169558046> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> to <:stunicon:841419289428492369> (voiceline: `give me the life...`) → <:omniguard:1138809234922934282><:spec:537340400273195028> → <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → <:fingerofdeath:1159434801938432010> → <:necroauto:1137809137401602109> → <:deathskulls:1159434663903899728> → <:necroauto:1137809137401602109> to utilise <:deathspark:1143642264850141205> → <:bloat:1159433682403201044>/<:commandskeleton:1137809194423160883> → Solak down → <:flank4:712073088296157185><:soulstrike:1137809142376058910> repeats depending on lp → <:bloat:1159433682403201044>
+Solak down → <:splitsoul:1137809168368148490> → <:soulstrikeflank:1156683164593430579> → <:soulstrikeflank:1156683164593430579> → <:soulstrikeflank:1156683164593430579>
+Charge pad #2 (preferably <500k lp Solak) → <:anti:535541306475151390> → build 3 <:residualsoul:1139453152169558046> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> to <:stunicon:841419289428492369> (voiceline: `give me the life...`) → <:omniguard:1138809234922934282><:spec:537340400273195028> (if available) → <:bloat:1159433682403201044>/<:commandskeleton:1137809194423160883> → Solak down → <:soulstrikeflank:1156683164593430579> repeats depending on lp → <:bloat:1159433682403201044>
 
 __Elf:__
 <:deflectrange:544195488317046812> + <:invokedeath:1137809121983336548> + <:vulnbomb:655341074235129858> → <:soulsap:1137809140476031057> → <:bloat:1159433682403201044> → <:commandskeleton:1137809194423160883> → build 5 <:residualsoul:1139453152169558046> +100% adren.
 
 __*Notes Phase 3:*__
 ⬥ Can fit in 4 abilities as Solak goes down before you go elf.
+⬥ after <:omniguard:1138809234922934282><:spec:537340400273195028>  use a rot such as  <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → <:fingerofdeath:1159434801938432010> → <:necroauto:1137809137401602109> → <:deathskulls:1159434663903899728> → <:necroauto:1137809137401602109> to utilise <:deathspark:1143642264850141205>
 ⬥ If high lp: <:fingerofdeath:1159434801938432010> if 4+ <:necrosis:1139452791878856805> to finish.
 ⬥ <:lifetransfer:1137809128136388819> if <:conjurearmy:1166094935066423348> < 35s upon exit.
 
@@ -98,7 +99,7 @@ __If <100% adren:__
 <:splitsoul:1137809168368148490> → (damageable) <:deathskulls:1159434663903899728> → <:bloat:1159433682403201044> → <:commandskeleton:1137809194423160883> → <:volleyofsouls:1159435029592686642> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> → build for <:omniguard:1138809234922934282><:spec:537340400273195028> if not dead.
 
 __If ≤3__ <:residualsoul:1139453152169558046>:
-<:bloat:1159433682403201044> → <:splitsoul:1137809168368148490> → <:commandskeleton:1137809194423160883> → (damageable) <:deathskulls:1159434663903899728> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010> → <:flank4:712073088296157185><:soulstrike:1137809142376058910>  → repeat <:flank4:712073088296157185><:soulstrike:1137809142376058910> till < 60k lp → <:deathguard90:1138809243143766118><:eofspec:746403211908481184>
+<:bloat:1159433682403201044> → <:splitsoul:1137809168368148490> → <:commandskeleton:1137809194423160883> → (damageable) <:deathskulls:1159434663903899728> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010> → <:soulstrikeflank:1156683164593430579> → repeat <:soulstrikeflank:1156683164593430579> till < 60k lp → <:deathguard90:1138809243143766118><:eofspec:746403211908481184>
 
 .
 > __**Video Example**__


### PR DESCRIPTION
- Dominion mines were in preset maker notes. now removed
- Soulsap in p1 was missing
- Life transfer was unnecessary after core
- Clarified p3 omniguardspec in p3 notes.
- Changed flank4+soulstrike emojis into flanksoulstrike emoji for consistency

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
