### PR TITLE
Update afk-kerapac.txt preset link was wrong

### DIFF
--- a/afk/afk-kerapac.txt
+++ b/afk/afk-kerapac.txt
@@ -77,7 +77,7 @@
     "fields": [
       {
         "name": "__Preset Suggestion & Breakdown__",
-        "value": "⬥ [Bow of the Last Guardian](https://pvme.github.io/preset-maker/#/yeKCfJjW8pm1FZRpzm4s)",
+        "value": "⬥ [Bow of the Last Guardian](https://pvme.github.io/preset-maker/#/Cv03Nta5rhqX1XGhDuhR)",
         "inline": true
       }
     ]


### PR DESCRIPTION
- preset link didn't match embed and showed necro kera.
- new preset was made based on old preset link, but sirenic changed to 4pc edrac to match embedded image.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## Sanity Checks
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
