### PR TITLE
Update necromancy.txt post-beta necro rot by wxrl

### DIFF
--- a/rs3-full-boss-guides/telos/necromancy.txt
+++ b/rs3-full-boss-guides/telos/necromancy.txt
@@ -47,73 +47,87 @@ An average kill at 2449% enrage is worth <:coins:698816156961603654> $data_pvme:
 ## __The Fight__
 .tag:fight
 ### Prebuild
-Pre-building stacks at wars is **recommended** as it allows you to achieve more consistent phase 1 and 2's. Ensure to <:devo:513190158728953857> **and** <:surge:535533810004262912> **properly** to ensure proper target cycle timing. For more details, read "*Target Cycling*" in <#1020754821906710588>.
+Pre-building stacks at wars is **recommended** as it allows you to achieve a more consistent phase 1 and 2.
 
-Dummy at War's retreat: <:soulsap:1137809140476031057> → <:threadsoffate:1137809172335951933> → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> (should end on 4 <:necrosis:1139452791878856805> 4 <:residualsoul:1139453152169558046> )
+Dummy at War's retreat: <:soulsap:1137809140476031057> → <:threadsoffate:1137809172335951933> → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> (should end on 4 <:necrosis:1139452791878856805> 4 <:residualsoul:1139453152169558046>)
 
-If wanting safer P1's, use <:devo:513190158728953857> before surge, however for faster P1's use <:commandskeleton:1137809194423160883>
+<:conjurearmy:1166094935066423348> + (<:sbslunars:565726489467682816>)<:veng:543478434953822208> + (<:sbslunars:565726489467682816>)<:disrupt:535614336207552523> → <:lifetransfer:1137809128136388819> → <:commandghost:1159434409913634816> + <:cinderbanes:513190158355660812> → <:invokedeath:1137809121983336548> →  <:invokelordofbones:1176968330582700174> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → (wait 2 ticks) → <:surge:535533810004262912> → <:commandskeleton:1137809194423160883> / <:limitless:641339233638023179> <:devo:513190158728953857>
 
-<:conjurearmy:1166094935066423348> + <:sbslunars:565726489467682816> <:veng:543478434953822208>→ <:lifetransfer:1137809128136388819> → <:invokedeath:1137809121983336548> → <:commandghost:1159434409913634816> → <:invokelordofbones:1176968330582700174> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → (wait 2 ticks) → <:surge:535533810004262912> → <:commandskeleton:1137809194423160883> / <:limitless:641339233638023179> <:devo:513190158728953857>
-
-*__Note:__
-⬥ if <:invokelordofbones:1176968330582700174> is not owned, skip in prebuild and use <:rod:513190159462825984> and/or <:asr:513190158472839208> instead of <:reaverring:839903943018283050> P1 to P4*
+*__Prebuild Notes:__
+⬥ Optional: to reduce P1-2 RNG up to 4k you can <:staffoflight:841419289319964763><:eofspec:746403211908481184> at adrenaline crystal.
+⬥ if <:invokelordofbones:1176968330582700174> is not owned, skip in prebuild and use <:rod:513190159462825984> or <:asr:513190158472839208> instead of <:reaverring:839903943018283050> P1 to P4*
 
 .
 ### Phase 1
-<:ingen:641339234111848463> <:praeswand:643166769518739477> tc <:smokecloud:856635090641879050> <:omniguard:1138809234922934282> <:touchofdeath:1137809175980810380> → <:deathskulls:1159434663903899728> → <:omniguard:1138809234922934282><:spec:537340400273195028>→ <:necroauto:1137809137401602109> → <:fingerofdeath:1159434801938432010> → <:necroauto:1137809137401602109> → <:fingerofdeath:1159434801938432010> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> → <:touchofdeath:1137809175980810380> → <:deathguard70:1138809262194294864><:eofspec:746403211908481184> if not phased
+<:ingen:641339234111848463> <:praeswand:643166769518739477> + (tc) + <:smokecloud:856635090641879050> + <:vulnbomb:655341074235129858> + <:omniguard:1138809234922934282> → <:touchofdeath:1137809175980810380> → <:deathskulls:1159434663903899728> → <:omniguard:1138809234922934282><:spec:537340400273195028>→ <:necroauto:1137809137401602109> → <:fingerofdeath:1159434801938432010> → <:necroauto:1137809137401602109> → <:fingerofdeath:1159434801938432010> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> → <:touchofdeath:1137809175980810380> → <:anti:535541306475151390> or <:deathguard70:1138809262194294864><:eofspec:746403211908481184> if not phased
 
 .
 ### Phase 2
-<:splitsoul:1137809168368148490> → <:bloat:1159433682403201044> → <:commandskeleton:1137809194423160883> → <:volleyofsouls:1159435029592686642> (on tendrils) → <:fingerofdeath:1159434801938432010> → <:touchofdeath:1137809175980810380> → <:necroauto:1137809137401602109> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> (phased)
+⬥ This phase's rotation varies slightly depending how many autos Telos still has remaining before tendrils.
+
+__2 autos:__ <:splitsoul:1137809168368148490> → <:bloat:1159433682403201044> → <:necroauto:1137809137401602109> → <:commandskeleton:1137809194423160883> → wait 1t + <:volleyofsouls:1159435029592686642> → <:touchofdeath:1137809175980810380> → <:fingerofdeath:1159434801938432010> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> → <:necroauto:1137809137401602109>
+
+__1 auto:__ <:splitsoul:1137809168368148490> → <:bloat:1159433682403201044> →  <:commandskeleton:1137809194423160883> → <:volleyofsouls:1159435029592686642> → <:fingerofdeath:1159434801938432010> → <:touchofdeath:1137809175980810380> → <:fingerofdeath:1159434801938432010> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> → <:necroauto:1137809137401602109>
+
+__0 autos:__ <:splitsoul:1137809168368148490> → <:bloat:1159433682403201044> →  <:volleyofsouls:1159435029592686642> → <:commandskeleton:1137809194423160883> → <:touchofdeath:1137809175980810380> → <:fingerofdeath:1159434801938432010> → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> → <:necroauto:1137809137401602109> <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109>
+
+*__P2 Notes:__
+⬥ Optionally (At higher enrages / long streaks):
+    •  <:res:535541258844635148>/<:divert:787904334377648130> telos' 3rd auto after tendrils
+    •   Use <:devo:513190158728953857> for onslaught hits.
+    •   Ensure ending with 85%+ adrenaline for safer P3.*
 
 .
 ### Phase 3
-<:bloat:1159433682403201044> + <:vulnbomb:655341074235129858> → <:commandskeleton:1137809194423160883> → <:soulsap:1137809140476031057> → <:touchofdeath:1137809175980810380> → <:deathskulls:1159434663903899728> + <:dive:1049378668197195808> red beam →   <:soulsap:1137809140476031057> → <:fingerofdeath:1159434801938432010> → <:necroauto:1137809137401602109> → <:soulsap:1137809140476031057> + <:surge:535533810004262912> drop spot → <:necroauto:1137809137401602109> (phased)
+<:bloat:1159433682403201044> + <:vulnbomb:655341074235129858> → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> → <:commandskeleton:1137809194423160883> → <:deathskulls:1159434663903899728> + <:dive:1049378668197195808> red beam → <:soulsap:1137809140476031057> → <:commandzombie:1137809191231295549> → <:fingerofdeath:1159434801938432010> + 2t <:surge:535533810004262912> to jump spot → <:soulsap:1137809140476031057> → <:necroauto:1137809137401602109> (phased) → <:divert:787904334377648130>
 
+*P3 notes:
+⬥ Replace first <:soulsap:1137809140476031057> by <:debil:535541278264393729> if priotizing safety.
+⬥ <:divert:787904334377648130> should catch a smite or nuke if not phased*
 .
 ### Phase 4
 Note: For information on how to use sticky bombs in p4 for minions effectively please see <#1020754537126035487>
 
-.
-__Drop__
-<:bloat:1159433682403201044> +<:vulnbomb:655341074235129858> → <:touchofdeath:1137809175980810380> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> → <:soulsap:1137809140476031057> + <:dive:1049378668197195808> font 1
+__Drop Down__
+<:bloat:1159433682403201044> → <:touchofdeath:1137809175980810380> → <:deathguard90:1138809243143766118><:eofspec:746403211908481184> → <:soulsap:1137809140476031057> + <:dive:1049378668197195808> font 1
 
-.
 __Font 1__
 <:divert:787904334377648130> → <:reflect:535541258786177064> → <:prep:535541258546970624> → <:freedom:535541258240786434> → <:soulsap:1137809140476031057> + <:stickybomb:655341074306301964> golems → <:touchofdeath:1137809175980810380> + move away → telos + <:volleyofsouls:1159435029592686642> → <:omniguard:1138809234922934282><:spec:537340400273195028> → <:conjurearmy:1166094935066423348> + <:dive:1049378668197195808><:surge:535533810004262912> font 2
 
-.
 __Font 2__
-<:necroauto:1137809137401602109> → <:commandghost:1159434409913634816> → <:anticlearheaded:867678154071998464> → <:res:535541258844635148> + <:stickybomb:655341074306301964> golems → <:threadsoffate:1137809172335951933> → <:soulsap:1137809140476031057> + move away → <:commandskeleton:1137809194423160883> → (target + <:vulnbomb:655341074235129858> telos → <:volleyofsouls:1159435029592686642> → <:deathguard70:1138809262194294864><:eofspec:746403211908481184> → <:dive:1049378668197195808> + <:surge:535533810004262912> font 3
+<:necroauto:1137809137401602109> → <:commandghost:1159434409913634816> → <:anticlearheaded:867678154071998464> → <:res:535541258844635148>/<:divert:787904334377648130> + <:stickybomb:655341074306301964> golems → <:threadsoffate:1137809172335951933> → <:soulsap:1137809140476031057> + move away → <:commandskeleton:1137809194423160883> → (target + <:vulnbomb:655341074235129858> telos → <:volleyofsouls:1159435029592686642> → <:deathguard70:1138809262194294864><:eofspec:746403211908481184> → <:dive:1049378668197195808> + <:surge:535533810004262912> font 3
 
 .
 __Font 3__
-<:prep:535541258546970624> → <:touchofdeath:1137809175980810380> → <:devo:513190158728953857> → <:res:535541258844635148> → <:freedom:535541258240786434> (equip <:rod:513190159462825984>) → <:invokelordofbones:1176968330582700174> → <:bloodsiphon:1159434279311380532> → (wait for instakill message) <:fingerofdeath:1159434801938432010> → (tc) golem <:necroauto:1137809137401602109> + <:sbslunars:565726489467682816> <:disrupt:535614336207552523>
+<:prep:535541258546970624> → <:touchofdeath:1137809175980810380> → <:devo:513190158728953857> → <:divert:787904334377648130> → <:freedom:535541258240786434> (equip <:rod:513190159462825984>) → <:invokelordofbones:1176968330582700174> → <:bloodsiphon:1159434279311380532> → (wait for instakill message) <:fingerofdeath:1159434801938432010> → (tc) golem <:necroauto:1137809137401602109> + (<:sbslunars:565726489467682816>)<:disrupt:535614336207552523>
 
-*__Notes:__
-⬥ Font 2: skip <:necroauto:1137809137401602109> if <:surge:535533810004262912> was on GCD
+*__P4 Notes:__
 ⬥ Font 2: <:commandskeleton:1137809194423160883> only if <:soulsap:1137809140476031057> is 1t before or on-tick for **`You dare to defy me?`** voiceline.
 ⬥ Font 3: if no <:invokelordofbones:1176968330582700174> can <:invokedeath:1137809121983336548> here instead of during prebuild.*
 
 .
 ### Phase 5
 Note: for more information on timing & moving efficiently throughout P5, read: <#1218300617399996426>
-.
-__Green/Black Golem__
-<:invokedeath:1137809121983336548> → (wait 2t) → <:surge:535533810004262912> → <:splitsoul:1137809168368148490> → <:dive:1049378668197195808> (into green beam, diagonal <:dive:1049378668197195808> → <:bloat:1159433682403201044> if back beam) + <:nat:535541258131865633> + <:vitality:654618235097972737> → <:deathskulls:1159434663903899728> → <:livingdeath:1159434908486357072> → <:deathskulls:1159434663903899728> → <:cade:535541306353778689> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010>
+
+__Side Beam__
+<:invokedeath:1137809121983336548> → (wait 2t) → <:surge:535533810004262912> → <:splitsoul:1137809168368148490> → <:dive:1049378668197195808> into green beam + <:nat:535541258131865633> + <:vitality:654618235097972737> → (<:anticlearheaded:867678154071998464> if <:redgolem:854335416294703135> →) <:deathskulls:1159434663903899728> → <:livingdeath:1159434908486357072> → <:deathskulls:1159434663903899728> → <:cade:535541306353778689> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010> → <:deathguard70:1138809262194294864><:eofspec:746403211908481184> → <:omniguard:1138809234922934282>'<:spec:537340400273195028>
 
 .
-__Red Golem__
-<:invokedeath:1137809121983336548> → (wait 2t) → <:surge:535533810004262912> → <:splitsoul:1137809168368148490> → <:dive:1049378668197195808> (into green beam, diagonal <:dive:1049378668197195808> → <:bloat:1159433682403201044> if back beam) + <:nat:535541258131865633> + <:vitality:654618235097972737> → <:anticlearheaded:867678154071998464> → <:deathskulls:1159434663903899728> → <:livingdeath:1159434908486357072> → <:deathskulls:1159434663903899728> → <:cade:535541306353778689> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010> → <:fingerofdeath:1159434801938432010>
+__Back Beam__
+<:invokedeath:1137809121983336548> → (wait 2t) → <:surge:535533810004262912> → <:splitsoul:1137809168368148490> → diagonal <:dive:1049378668197195808> + <:commandzombie:1137809191231295549> + <:stickybomb:655341074306301964> corner → <:touchofdeath:1137809175980810380> →  <:nat:535541258131865633> + <:vitality:654618235097972737> → <:deathskulls:1159434663903899728> → <:livingdeath:1159434908486357072> → <:deathskulls:1159434663903899728> → <:cade:535541306353778689> → <:fingerofdeath:1159434801938432010> → <:deathguard70:1138809262194294864><:eofspec:746403211908481184> → <:omniguard:1138809234922934282>'<:spec:537340400273195028>
 
-*__Notes:__
-⬥ For safety <:reflect:535541258786177064> can be used in p5 between <:splitsoul:1137809168368148490> and <:nat:535541258131865633>
-⬥ For speeds: can equip <:reaverring:839903943018283050> after <:cade:535541306353778689>, and can <:dive:1049378668197195808> + <:surge:535533810004262912> to red beam < 100k health for a slightly faster p5.*
+*__P5 Notes:__
+⬥ For safety <:reflect:535541258786177064> can be used in p5 between <:invokedeath:1137809121983336548> and <:splitsoul:1137809168368148490>
+⬥ For backbeam you can <:stickybomb:655341074306301964> the corner (see video @24:00).
+    • if <:redgolem:854335416294703135> this also works, or replace <:touchofdeath:1137809175980810380> by <:anticlearheaded:867678154071998464> instead.
+⬥ For speeds: can equip <:reaverring:839903943018283050> after <:cade:535541306353778689>, and can <:surge:535533810004262912>+<:dive:1049378668197195808> to red beam after <:fingerofdeath:1159434801938432010> for a slightly faster p5.*
 
 .
 ## __Example kills__
 .tag:examples
-[Necro Telos example kills](<https://www.youtube.com/watch?v=ReXIiJVFpNM>)
+⬥ [Necro Telos example kills](<https://www.youtube.com/watch?v=k_ncO18JYFM>)
+.
+⬥ [Necro Telos P5 backbeam + red golem example](<https://youtu.be/k_ncO18JYFM?t=1440>)
 
 .
 {


### PR DESCRIPTION
averages 2:45-2:50 kill times.
- added more notes for safer kills (for 4k/killstreak) per phase.
- expanded on p2 rotations depending on autos remaining
- rotational tweaks on p3-5.
- usage of a P5 backbeam sticky bomb strat.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
