### PR TITLE
Create earlyedraco.txt

### DIFF
--- a/commands/earlyedraco.txt
+++ b/commands/earlyedraco.txt
@@ -1,0 +1,14 @@
+{
+  "embed": {
+    "title": "__Early Elite Dracolich Armour Bad__",
+    "description": "Elite Dracolich Armour <:edracocoif:1179717359934640168><:edracobody:1179717430436704306><:edracochaps:1179717529015427146><:edracoboots:1179717602151514123><:edracogloves:1179717613769728100> ( <:coins:698816156961603654> $data_pvme:Unlocks!E144$) should not be bought early.",
+    "color": 39423,
+    "fields": [
+      {
+        "name": "__Justification__",
+        "value": "⬥ Elite Dracolich Armour is **only** worth it due to its synergy with the rest of the range toolkit such as <:bolg:994189289623662702>, <:sgb:626466665848242186><:eof:787526151978614824>, <:ecb:615618531937222657><:eof:787526151978614824> and <:grico:787904334812807238>\n\u00a0\u00a0\u00a0\u00a0• See `!big4` for price information\n⬥ Before those essential upgrades, Elite Dracolich Armour is **not** worth its cost.\n⬥ Instead, use normal Sirenic Armour <:sirenicmask:643846959454617610><:sirenicbody:643846948570267648><:sireniclegs:643846938537623564> ( <:coins:698816156961603654> $data_pvme:Unlocks!E95$) and follow <#1024668611094253568>\n⬥ Note: the Dracolich Armour <:dracolichcoif:1179716885265252382><:dracolichbody:1179717045412180019><:dracolichchaps:1179717051305177158><:dracolichboots:1179717039867314226><:dracolichgloves:1179717057298825296> set effect and Elite Dracolich Armour set effect do **not** stack.\n\u00a0\u00a0\u00a0\u00a0• Currently it is not recommended to buy Dracolich Armour."
+      }
+    ]
+  }
+}
+.embed:json


### PR DESCRIPTION
explain why buying elite dracolich armour early on is bad.
- first get the big four and use normal sirenic.
- regular dracolich armour effects do not stack with the elite dracolich armour effects.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
