### PR TITLE
update name and link for Wars retreat

### DIFF
--- a/basic-guides/raksha-basic.txt
+++ b/basic-guides/raksha-basic.txt
@@ -29,7 +29,7 @@
 ⬥ Prayer flicking is crucial and mandatory as Raksha is able to use all three combat styles.
 ⬥ Raksha uses a special attack after every 4 normal attacks during phases 1-3, and after every 2 normal attacks during phase 4.
 ⬥ <:p6:712073088769982475> <:er4:1214416401561952296> on <:lanispear:839903893177106454> to ensure 1k minimum damage with <:bd:535532854281764884>
-    • To see if you meet the minimum damage requirement, go to dummies at war's retreat, set them to minimum hit mode, and use <:lanispear:839903893177106454> <:bd:535532854281764884> with your Raksha gear.
+    • To see if you meet the minimum damage requirement, go to dummies at war's Retreat, set them to minimum hit mode, and use <:lanispear:839903893177106454> <:bd:535532854281764884> with your Raksha gear.
     • If you did not meet the requirement, use to <:turmoil:583429936606347280> / <:Malevolence:513190159416557573> while using <:bd:535532854281764884>
 
 .

--- a/basic-guides/raksha-basic.txt
+++ b/basic-guides/raksha-basic.txt
@@ -29,7 +29,7 @@
 ⬥ Prayer flicking is crucial and mandatory as Raksha is able to use all three combat styles.
 ⬥ Raksha uses a special attack after every 4 normal attacks during phases 1-3, and after every 2 normal attacks during phase 4.
 ⬥ <:p6:712073088769982475> <:er4:1214416401561952296> on <:lanispear:839903893177106454> to ensure 1k minimum damage with <:bd:535532854281764884>
-    • To see if you meet the minimum damage requirement, go to dummies at war's Retreat, set them to minimum hit mode, and use <:lanispear:839903893177106454> <:bd:535532854281764884> with your Raksha gear.
+    • To see if you meet the minimum damage requirement, go to dummies at War's Retreat, set them to minimum hit mode, and use <:lanispear:839903893177106454> <:bd:535532854281764884> with your Raksha gear.
     • If you did not meet the requirement, use to <:turmoil:583429936606347280> / <:Malevolence:513190159416557573> while using <:bd:535532854281764884>
 
 .

--- a/dpm-advice/dpm-advice-melee.txt
+++ b/dpm-advice/dpm-advice-melee.txt
@@ -528,7 +528,7 @@ This section will examine equipment that is useful for Melee <:melee:10961308672
     • Raksha (anima damage boost in phase 4).
     • Seiryu (at the last crystal).
     • Telos (under <:revenge:535541259645878302> and <:zerk:535532854004678657> in phase 5).
-    • At War's retreat (using the adrenaline crystals) for fights where you <:zerk:535532854004678657> at the beginning.
+    • At War's Retreat (using the adrenaline crystals) for fights where you <:zerk:535532854004678657> at the beginning.
 .
 ⬥ **Between <:abyssalscourge:947871842469834832> and Lengs <:lengmh:883134308146098227> <:lengoh:883134308070604870>, Drygores <:drygorelongmh:513190158900658180> <:drygorelongoh:852939843767369783> and Khopeshes <:khopeshmh:513206794844110858> <:khopeshoh:513206794752098327> are mostly irrelevant in the current meta.**
 

--- a/getting-started/new-to-pvm/early-game-combat.txt
+++ b/getting-started/new-to-pvm/early-game-combat.txt
@@ -88,7 +88,7 @@ We also have some pre-created ability bars and gear progression suggestions to h
 .
 ## __War's Retreat & Bossing__
 .tag:wars
-⬥ [War's Retreat](<https://runescape.wiki/w/War%27s_retreat>) is a PvM hub that can be accessed at <:combat:797896050370281523> Level 60 north of Draynor lodestone.
+⬥ [War's Retreat](<https://runescape.wiki/w/War%27s_Retreat>) is a PvM hub that can be accessed at <:combat:797896050370281523> Level 60 north of Draynor lodestone.
     • This place can serve as a free, unlimited place to teleport to for easy bank access, restoring prayer and more as you increase your boss kill count.
     • To unlock the teleport, it is recommended to kill 10 lower level bosses such as [Arch-Glacor (0 mechanics)](<https://runescape.wiki/w/Arch-Glacor>), [King Black Dragon](<https://runescape.wiki/w/King_Black_Dragon>), [Giant Mole](<https://runescape.wiki/w/Giant_mole>), or [Croesus](<https://runescape.wiki/w/Croesus>).
     • For more info on bossing see <#1020546518941454438>

--- a/new-to-pvm/early-game-combat.txt
+++ b/new-to-pvm/early-game-combat.txt
@@ -88,7 +88,7 @@ We also have some pre-created ability bars and gear progression suggestions to h
 .
 ## __War's Retreat & Bossing__
 .tag:wars
-⬥ [War's Retreat](<https://runescape.wiki/w/War%27s_retreat>) is a PvM hub that can be accessed at <:combat:797896050370281523> Level 60 north of Draynor lodestone.
+⬥ [War's Retreat](<https://runescape.wiki/w/War%27s_Retreat>) is a PvM hub that can be accessed at <:combat:797896050370281523> Level 60 north of Draynor lodestone.
     • This place can serve as a free, unlimited place to teleport to for easy bank access, restoring prayer and more as you increase your boss kill count.
     • To unlock the teleport, it is recommended to kill 10 lower level bosses such as [Arch-Glacor (0 mechanics)](<https://runescape.wiki/w/Arch-Glacor>), [King Black Dragon](<https://runescape.wiki/w/King_Black_Dragon>), [Giant Mole](<https://runescape.wiki/w/Giant_mole>), or [Croesus](<https://runescape.wiki/w/Croesus>).
     • For more info on bossing see <#1020546518941454438>

--- a/rs3-full-boss-guides/rex-matriarchs.txt
+++ b/rs3-full-boss-guides/rex-matriarchs.txt
@@ -92,7 +92,7 @@ Gear used for the methods below will mostly be BIS, you can generally substitute
     "fields": [
       {
         "name": "__Solo Pthentraken__",
-        "value": "⬥ Kill Pthentraken using a <:gdeathsswift:994644354536837121> and bank ASAP. This method should be replicable for the other 2 matriarchs giving similar kph.\n\u00a0\u00a0\u00a0\u00a0• While waiting for death animation, build adrenaline on a nearby matriarch.\n\u00a0\u00a0\u00a0\u00a0• At war's retreat, <:surge:535533810004262912> to use Altar of War, <:bd:535532854281764884> to bank and <:surge:535533810004262912> to Adrenaline Crystals.\n\u00a0\u00a0\u00a0\u00a0• Example setup for actively killing Pthentraken (outdated): [Preset](https://img.pvme.io/images/P2L7dOr.png) [Rotation](https://img.pvme.io/images/MSrN9Pe.png) [Example - 60kph](https://www.twitch.tv/videos/1033769908)\n\u200B"
+        "value": "⬥ Kill Pthentraken using a <:gdeathsswift:994644354536837121> and bank ASAP. This method should be replicable for the other 2 matriarchs giving similar kph.\n\u00a0\u00a0\u00a0\u00a0• While waiting for death animation, build adrenaline on a nearby matriarch.\n\u00a0\u00a0\u00a0\u00a0• At war's Retreat, <:surge:535533810004262912> to use Altar of War, <:bd:535532854281764884> to bank and <:surge:535533810004262912> to Adrenaline Crystals.\n\u00a0\u00a0\u00a0\u00a0• Example setup for actively killing Pthentraken (outdated): [Preset](https://img.pvme.io/images/P2L7dOr.png) [Rotation](https://img.pvme.io/images/MSrN9Pe.png) [Example - 60kph](https://www.twitch.tv/videos/1033769908)\n\u200B"
       }
     ]
   }

--- a/rs3-full-boss-guides/rex-matriarchs.txt
+++ b/rs3-full-boss-guides/rex-matriarchs.txt
@@ -92,7 +92,7 @@ Gear used for the methods below will mostly be BIS, you can generally substitute
     "fields": [
       {
         "name": "__Solo Pthentraken__",
-        "value": "⬥ Kill Pthentraken using a <:gdeathsswift:994644354536837121> and bank ASAP. This method should be replicable for the other 2 matriarchs giving similar kph.\n\u00a0\u00a0\u00a0\u00a0• While waiting for death animation, build adrenaline on a nearby matriarch.\n\u00a0\u00a0\u00a0\u00a0• At war's Retreat, <:surge:535533810004262912> to use Altar of War, <:bd:535532854281764884> to bank and <:surge:535533810004262912> to Adrenaline Crystals.\n\u00a0\u00a0\u00a0\u00a0• Example setup for actively killing Pthentraken (outdated): [Preset](https://img.pvme.io/images/P2L7dOr.png) [Rotation](https://img.pvme.io/images/MSrN9Pe.png) [Example - 60kph](https://www.twitch.tv/videos/1033769908)\n\u200B"
+        "value": "⬥ Kill Pthentraken using a <:gdeathsswift:994644354536837121> and bank ASAP. This method should be replicable for the other 2 matriarchs giving similar kph.\n\u00a0\u00a0\u00a0\u00a0• While waiting for death animation, build adrenaline on a nearby matriarch.\n\u00a0\u00a0\u00a0\u00a0• At War's Retreat, <:surge:535533810004262912> to use Altar of War, <:bd:535532854281764884> to bank and <:surge:535533810004262912> to Adrenaline Crystals.\n\u00a0\u00a0\u00a0\u00a0• Example setup for actively killing Pthentraken (outdated): [Preset](https://img.pvme.io/images/P2L7dOr.png) [Rotation](https://img.pvme.io/images/MSrN9Pe.png) [Example - 60kph](https://www.twitch.tv/videos/1033769908)\n\u200B"
       }
     ]
   }

--- a/rs3-full-boss-guides/telos/necromancy.txt
+++ b/rs3-full-boss-guides/telos/necromancy.txt
@@ -49,7 +49,7 @@ An average kill at 2449% enrage is worth <:coins:698816156961603654> $data_pvme:
 ### Prebuild
 Pre-building stacks at wars is **recommended** as it allows you to achieve a more consistent phase 1 and 2.
 
-Dummy at War's retreat: <:soulsap:1137809140476031057> → <:threadsoffate:1137809172335951933> → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> (should end on 4 <:necrosis:1139452791878856805> 4 <:residualsoul:1139453152169558046>)
+Dummy at War's Retreat: <:soulsap:1137809140476031057> → <:threadsoffate:1137809172335951933> → <:touchofdeath:1137809175980810380> → <:soulsap:1137809140476031057> (should end on 4 <:necrosis:1139452791878856805> 4 <:residualsoul:1139453152169558046>)
 
 <:conjurearmy:1166094935066423348> + (<:sbslunars:565726489467682816>)<:veng:543478434953822208> + (<:sbslunars:565726489467682816>)<:disrupt:535614336207552523> → <:lifetransfer:1137809128136388819> → <:commandghost:1159434409913634816> + <:cinderbanes:513190158355660812> → <:invokedeath:1137809121983336548> →  <:invokelordofbones:1176968330582700174> → <:livingdeath:1159434908486357072> + <:adrenrenewal:736298121704767538> → (wait 2 ticks) → <:surge:535533810004262912> → <:commandskeleton:1137809194423160883> / <:limitless:641339233638023179> <:devo:513190158728953857>
 

--- a/slayer/camel-warriors.txt
+++ b/slayer/camel-warriors.txt
@@ -80,7 +80,7 @@ The fastest way to kill camels relies on doing trips to a player owned dungeon w
 
 ⬥ Occasionally, the camel will not phase despite <:dragonlongsword:1048592042399383713> <:eofspec:746403211908481184> hitting for significantly less than 20,000. When this happens, use a 188 <:cleave:535532878616985610> <:sever:535532879577612298> to guarantee the kill on the camel. <:gfury:535532879334080527> or <:smashgop:994929821727604808> may not deal sufficient raw damage to finish the camel off.
 
-1. Use <:dba:603979368850653216> <:spec:537340400273195028> at War's retreat with <:asr:513190158472839208> equipped + Kalg spec <:kalgscroll:841409588954923049>
+1. Use <:dba:603979368850653216> <:spec:537340400273195028> at War's Retreat with <:asr:513190158472839208> equipped + Kalg spec <:kalgscroll:841409588954923049>
 2. Swap to <:terramaul:602561894829522954> <:reaverring:839903943018283050> and get back 90% or more adrenaline before teleporting to the Menaphos house portal.
     a. Use a Menaphos tablet or the House teleport spell if your house is attuned to Menaphos.
     b. You can activate <:excal:641337999170207763> **from action bar** without interrupting adren gaining if not on full HP.


### PR DESCRIPTION
This pull request updates the references for War's retreat to be War's Retreat, this brings the below guides inline with the remaining,
I have also fixed the link to the wiki so it is not a redirect :) 

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
