### PR TITLE
Remove outdated AFK Rathis bars

### DIFF
--- a/afk/afk-rathis.txt
+++ b/afk/afk-rathis.txt
@@ -18,7 +18,7 @@ Choices for aura which affects how afk kills can be. They are listed in order of
 {
   "embed": {
     "title": "__Mandatory AFK Requirements__",
-    "description":"This setup should reliably allow you to reliably afk Rathis.\nThe following are required or this method will not work:\n\n⬥ Necklace of Salamancy <:necklaceofsalamancy:970657245312467004> **OR** Essence of Finality <:eof:787526151978614824>\n⬥ Either:\n\u00a0\u00a0\u00a0\u00a0• Masterwork Spear of Annihilation <:mwspear:694566917456789554>\n\u00a0\u00a0\u00a0\u00a0• Abyssal Scourge and Dark Sliver of Leng <:abyssalscourge:947871842469834832> <:lengoh:883134308070604870> if <:necklaceofsalamancy:970657245312467004> is owned\n⬥ Full Vestments of Havoc <:vestmentsofhavochood:994189297659940904> <:vestmentsofhavoctop:994189295592161291> <:vestmentsofhavocbottom:994189293515980902> <:vestmentsofhavocboots:994189291515285544>\n⬥ Adrenaline retention <:infernalpuzzlebox:994189299681607800> **OR** Persistent Rage <:persistentrage:739965637056659567>\n⬥ Conservation of Energy <:conservationofenergy:697808773711921195>\n⬥ Penance Powder <:powderofpenance:928221126360969226> to upkeep prayer\n⬥ Igneous Kal-Ket <:igneouskalket:902209626404192316> / Kal-Zuk <:igneouskalzuk:902209626479685734>\n⬥ Ring of Vigour passive effect <:rov:513201065877831680> <:warpedgem:968908526955167774>\n⬥ Elder Overload Salve <:elderovlsalve:648976643687317532> is active\n\u00a0\u00a0\u00a0\u00a0• A Salve is **required** for the <:superantipoison:841409588884406272> effect.\n\u00a0\u00a0\u00a0\u00a0• Normal Elder Overloads <:elderovl:841419289831800882> can be used with Super Prayer Renewals <:SuperPrayerRenewal:547603714681339915> if the Venomblood <:venomblood:841419289714229258> perk is owned.\n\u00a0\u00a0\u00a0\u00a0• Irit incense sticks <:IritSticks:690987265371144202> **DO NOT** mitigate Rathis' poison damage.\n⬥ Weapon poison +++ <:weppoison:689525476158472288>\n⬥ Soulsplit <:soulsplit:615613924506599497> is active\n⬥ Turmoil <:turmoil:583429936606347280> or Malevolence <:Malevolence:513190159416557573> is active\n⬥ Auto-retaliate <:autoretaliate:1084799717726228530> is active",
+    "description":"This setup should reliably allow you to reliably afk Rathis.\nThe following are required or this method will not work:\n\n⬥ Necklace of Salamancy <:necklaceofsalamancy:970657245312467004>\n⬥ Abyssal Scourge and Dark Sliver of Leng <:abyssalscourge:947871842469834832> <:lengoh:883134308070604870>\n⬥ Full Vestments of Havoc <:vestmentsofhavochood:994189297659940904> <:vestmentsofhavoctop:994189295592161291> <:vestmentsofhavocbottom:994189293515980902> <:vestmentsofhavocboots:994189291515285544>\n⬥ Adrenaline retention <:infernalpuzzlebox:994189299681607800> **OR** Persistent Rage <:persistentrage:739965637056659567>\n⬥ Conservation of Energy <:conservationofenergy:697808773711921195>\n⬥ Penance Powder <:powderofpenance:928221126360969226> to upkeep prayer\n⬥ Igneous Kal-Ket <:igneouskalket:902209626404192316> / Kal-Zuk <:igneouskalzuk:902209626479685734>\n⬥ Ring of Vigour passive effect <:rov:513201065877831680> <:warpedgem:968908526955167774>\n⬥ Elder Overload Salve <:elderovlsalve:648976643687317532> is active\n\u00a0\u00a0\u00a0\u00a0• A Salve is **required** for the <:superantipoison:841409588884406272> effect.\n\u00a0\u00a0\u00a0\u00a0• Normal Elder Overloads <:elderovl:841419289831800882> can be used with Super Prayer Renewals <:SuperPrayerRenewal:547603714681339915> if the Venomblood <:venomblood:841419289714229258> perk is owned.\n\u00a0\u00a0\u00a0\u00a0• Irit incense sticks <:IritSticks:690987265371144202> **DO NOT** mitigate Rathis' poison damage.\n⬥ Weapon poison +++ <:weppoison:689525476158472288>\n⬥ Soulsplit <:soulsplit:615613924506599497> is active\n⬥ Turmoil <:turmoil:583429936606347280> or Malevolence <:Malevolence:513190159416557573> is active\n⬥ Auto-retaliate <:autoretaliate:1084799717726228530> is active",
     "color": 39423,
     "footer": {
       "text": "Cutting corners will result in failure"
@@ -49,22 +49,10 @@ Choices for aura which affects how afk kills can be. They are listed in order of
 .
 ### Action Bar
 .tag:bar
-⬥ **Revo Bar** for <:abyssalscourge:947871842469834832> <:lengoh:883134308070604870> 54-57 KPH, requires <:persistentrage:739965637056659567>
+⬥ **Revo Bar** for <:abyssalscourge:947871842469834832> <:lengoh:883134308070604870> 54-57 KPH
 .img:https://img.pvme.io/images/nSzKFTp2BH.png
 
 .
-**Note: The following ability bars are from before the combat changes on 4th March 2024.
-If you have new bar suggestions tell us in <#1020853673317908500>**
-
-⬥ **Revo Bar** for <:mwspear:694566917456789554> 54 KPH, requires <:persistentrage:739965637056659567>
-.
-.img:https://img.pvme.io/images/cgqenfYnpr.png
-.
-⬥ **Revo Bar** for <:mwspear:694566917456789554> if **not** using <:persistentrage:739965637056659567>
-.img:https://img.pvme.io/images/ZioLWPr.png
-.
-⬥ **Revo Bar** for <:abyssalscourge:947871842469834832> <:lengoh:883134308070604870> if **not** using <:persistentrage:739965637056659567>
-.img:https://img.pvme.io/images/0OQ9EPc.png
 ### Positioning
 .tag:pos
 ⬥ Position yourself in melee distance to the east of where Rathis Spawns.


### PR DESCRIPTION
# PvME Change Submission
Removes outdated AFK Rathis bars and tidies up the requirements section to assume Salamancy and current weapon combo. Can adjust again once a MW Spear bar is available and tested

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
