### PR TITLE
Update range-ent.txt for faster P1 phases

### DIFF
--- a/rs3-full-boss-guides/angel-of-death-7s/range-ent.txt
+++ b/rs3-full-boss-guides/angel-of-death-7s/range-ent.txt
@@ -61,7 +61,7 @@ _Note:
 <:wenarrow:971025697046925362> <:gricocaroming:867678153966878740> <:deathsporearrows:900758234527301642> → <:gdeathsswift:994644354536837121> → <:wenarrow:971025697046925362> <:stormshards:536256663641128971> → <:ecb:615618531937222657> <:eofspec:746403211908481184> → wait 1 tick + <:fularrow:971025696958853180> <:snipe:535541258425204770> → <:bolg:994189289623662702> <:spec:537340400273195028> + equip <:edracogloves:1179717613769728100> → <:wenarrow:971025697046925362> <:piercing:535541258538450944> → <:gconc:869285393223254107> → <:dbreath:535533833391702017> → <:tsunami:535533809995874304>
 
 _Note:
-⬥ Adjust <:snipe:535541258425204770> accordingly to phase timing.  This rotation assumes <:aod:580167371365548042> P1 phased 2 ticks after <:zammybow:1215929540908679208> <:eofspec:746403211908481184>_
+⬥ Adjust <:snipe:535541258425204770> accordingly to phase timing.  This rotation assumes <:aod:580167371365548042> P1 phased 2 ticks after <:zammybow:1215929540908679208> <:eofspec:746403211908481184>. If you don't have to wait 1 tick for <:snipe:535541258425204770>, do 4taa <:rubyaurora:574292444791963659> + <:tsunami:535533809995874304>_
 
 .
 ### __Phase 3__


### PR DESCRIPTION
Faster P1 Phases require Rangers to loose a tick P2, so that necroers can still follow their rotations
