### PR TITLE
Necromancy Job Gauges has been deprecated - replace it with Job Gauges (a rewrite by same developer) 

### DIFF
--- a/miscellaneous-information/alt1.txt
+++ b/miscellaneous-information/alt1.txt
@@ -88,17 +88,14 @@ In addition to the default apps that come with Alt1, there are a number of other
 .
 ### Combat Apps
 .tag:combat
-⬥ **Better Buffs Bar** - displays buffs in the order *you* decide on
-```alt1://addapp/https://nadyanayme.github.io/BetterBuffsBar/dist/appconfig.json```
-
-⬥ **Necro Job Gauge** - tracks Necromancy conjures/souls/stacks in an FFXIV-inspired "job gauge"
-```alt1://addapp/https://nadyanayme.github.io/NyusNecroJobGauge/dist/appconfig.json```
-
 ⬥ **Barrows Helper** - track killed brothers, solve doors and displays droprates
 ```alt1://addapp/https://markvsrs.github.io/BarrowsHelperSrc/appconfig.json```
 
 ⬥ **Better AoD** - improved minion order tracker over the default Alt1 tracker
 ```alt1://addapp/https://cgyi4.csb.app/appconfig.json```
+
+⬥ **Better Buffs Bar** - displays buffs in the order *you* decide on
+```alt1://addapp/https://nadyanayme.github.io/BetterBuffsBar/dist/appconfig.json```
 
 ⬥ **BoLG Tracker** - shows BoLG <:bolg:994189289623662702> stacks more clearly
 ```alt1://addapp/https://holycoil.nl/alt1/bolg/appconfig.json```
@@ -106,17 +103,20 @@ In addition to the default apps that come with Alt1, there are a number of other
 ⬥ **Dharok Relic** - shows the %DPS boost from Berserker's Fury
 ```alt1://addapp/https://holycoil.nl/alt1/DharokRelic/appconfig.json```
 
-⬥ **Vorago Timer** - shows Target Cycle (TC) timings for Vorago phases
-```alt1://addapp/https://holycoil.nl/alt1/VoragoTag/appconfig.json```
+⬥ **Igor's Presets** - Boss Presets Hub for Multiple bosses
+```https://github.com/IgorsCC/afkwarden-presets/blob/master/readme.md```
+
+⬥ **Job Gauges** - FFXIV-inspired job gauges for Runescape combat styles. Currently only Necromancy is supported.
+```alt1://addapp/https://nadyanayme.github.io/job-gauges/dist/appconfig.json```
 
 ⬥ **Slayer Tasks** - helps decide what <:slayer:797896049548066857> task to pick when using <:slayervip:975284344597934120> tickets
 ```alt1://addapp/https://unlishema.github.io/slayerassistant/appconfig.json```
 
+⬥ **Vorago Timer** - shows Target Cycle (TC) timings for Vorago phases
+```alt1://addapp/https://holycoil.nl/alt1/VoragoTag/appconfig.json```
+
 ⬥ **Zamorak Specs** - shows the next special attack at Zamorak
 ```alt1://addapp/https://holycoil.nl/alt1/zamorak/appconfig.json```
-
-⬥ **Igor's Presets** - Boss Presets Hub for Multiple bosses
-```https://github.com/IgorsCC/afkwarden-presets/blob/master/readme.md```
 
 .
 ### Skilling Apps


### PR DESCRIPTION
Sort combat apps alphabetically - swap out NJG (now deprecated) for Job Gauges. When my plugins were added they were added to the top of the list by whoever added them. For the sake of fairness and remaining unbiased I've sorted the plugins alphabetically instead. Though if that is unwanted I can rescind this PR and just swap out NJG for Job Gauges.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x ] - The title of this pull request clearly describes the change I would like to make.
- [x ] - If there are multiple changes in this pull request, they are all related.
- [x ] - I have tried to write clear a commit message(s) that describes the changes I made.
