### PR TITLE
Update solo-hard-mode-necromancy.txt

### DIFF
--- a/rs3-full-boss-guides/vorago/solo-hard-mode-necromancy.txt
+++ b/rs3-full-boss-guides/vorago/solo-hard-mode-necromancy.txt
@@ -58,15 +58,10 @@
 .
 ⬥ <:vitality:654618235097972737> Powerburst of Vitality is used on Phases 1, 6, and 8
     • The rest of the doses are for tanking Teamsplits or Green Bombs P10/11
-
 ⬥  <:numbingroot:1285852547453685781> Numbing root to help clear bleeds on Phases 2, 5, 10 (Purple Bomb), and 11 (Vitalis)
-    • The rest of the doses are for tanking Teamsplits or Green Bombs P10/11
-
 ⬥ <:wardentop90:1142770709530161192> <:wardenlegs90:1142770705688174652> for hitpoints <:constitution:689509250887712902> while tanking green bombs + Turtling <:turtling4:712073737377284146> switch
-
 ⬥ <:dommine:662249620579155968> For dealing with Vitalis
     • Not needed on TS week
-
 ⬥ <:graspingpouchblack:892816436974735361> <:graspingpouchblue:892816437406728252> <:graspingpouchpink:892816437503221830> Runes for: <:sbslunars:565726489467682816> <:disrupt:535614336207552523> <:prismofrestoration:938475261366784070> <:smokecloud:856635090641879050>
     • <:spiritualhealing:1091050892142325780> can also be used on extremely long encounters
 
@@ -413,13 +408,15 @@
 .
 ### __Vitalis Orbs and Red Bombs__
 .
-⬥ **2-4 Vitalis spawn every orb in hardmode**
+⬥ **3-5 Vitalis spawn every orb in hardmode**
+    • If you stand on the orb, one less than normal will spawn (2-4)
     • Often you will not have line of sight of all of them
     • Multiple can spawn on the same tile
 ⬥ **The goal should be to instantly deal with vits**, and often you will want to be under <:cade:535541306353778689>
 ⬥ Necromancy alleviates most of the issues of vits once you get used to the timing
-    • <:dommine:662249620579155968> + <:invokedeath:1137809121983336548> → <:threadsoffate:1137809172335951933> → <:volleyofsouls:1159435029592686642> / <:deathguard90:1138809243143766118> <:eofspec:1257438999794946099> should deal with them
+    • <:dommine:662249620579155968> + <:threadsoffate:1137809172335951933> → <:volleyofsouls:1159435029592686642> / <:deathguard90:1138809243143766118> <:eofspec:1257438999794946099> should deal with them
         ⬩ Make sure to have 5 <:residualsoul:1139453152169558046> or at least 8 <:necrosis:1139452791878856805>
+        ⬩ If you don't <:invokedeath:1137809121983336548> should be used prior to <:threadsoffate:1137809172335951933> (or if in general you aren't killing them with your first ability)
 
 ⬥ Target cycle before you can see them physically spawn (usually on vit orb explosion)
     • It is worth it to lose ticks while vit orb is coming out to get the target cycle timing correct


### PR DESCRIPTION
changed # of vit spawns to say 3-5 with a note saying 2-4 if you stand on the orb
removed invoke death from main method of dealing with vit orb and added a note to use it if you dont have enough stacks / killing them first ability

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
