### PR TITLE
Update Nakatra Combat Achievement Guide

### DIFF
--- a/combat-achievements/nakatra-ca.txt
+++ b/combat-achievements/nakatra-ca.txt
@@ -14,12 +14,12 @@ This guide will go over how to complete the Grandmaster Speed Killer Combat Achi
     "title": "",
     "color": 39423,
     "image": {
-            "url": "https://img.pvme.io/images/NvuWVmTNM5.png"
+            "url": "https://img.pvme.io/images/cWXLEqGlt3.png"
         },
     "fields": [
 {
         "name": "__Preset Suggestions__",
-        "value": "⬥ [Melee Preset](https://pvme.io/preset-maker/#/07hQYbi6ielKTZlvdXeb)",
+        "value": "⬥ [Melee Preset](https://pvme.github.io/preset-maker/#/8vTTW6mFgMAZMTEDqyB1)",
         "inline": true
       }
     ]
@@ -37,31 +37,30 @@ This guide will go over how to complete the Grandmaster Speed Killer Combat Achi
 ⬥ Drink <:spiritualprayer:651079281882955787> throughout the fight to juice <:ripperpouch:703581275453128714>
 ⬥ Use <:veng:543478434953822208> at <:war:1005552206302416986> so its off cooldown for P1
 ⬥ All floor AoE attacks are dodged appropriately using <:bd:535532854281764884>
-⬥ <:consecratedkeris:1334318846202478615> is used for all bleeds, <:mwspear:694566917456789554> is only used for <:zekkil:903244090953588787> <:eofspec:1257438999794946099> in P1 and <:cleave:535532878616985610> in the Shadowsands
+⬥ <:consecratedkeris:1334318846202478615> is used for all bleeds, <:zekkil:903244090953588787> is only used for <:zekkil:903244090953588787> <:spec:537340400273195028>, <:smash:535532879820619786>, and <:cleave:535532878616985610>
+⬥ Ring of Retribution is used for <:reflect:535541258786177064>
 
 .
 ### __Phase 1__
 <:dba:603979368850653216> <:spec:537340400273195028> → wait for 120% adren → <:zerk:535532854004678657> + <:adrenrenewal:736298121704767538> → <:vulnbomb:655341074235129858> + <:nip:537336877900890135> + <:gbarge:535532879250456578> + <:callfollower:933299003121078332> → 4t <:smokecloud:856635090641879050> + <:destroy:535532879330148352> → 5t <:gflurry:535532879283879977> → equip <:jawsoftheabyss:947871842595639306> + <:gfury:535532879334080527> → <:veng:543478434953822208> + <:backhandflank:867678153854025779> + <:escape:535541258832052231> → <:assault:535532855191928842> → <:overpower:535532879334080517>
 
 ### __Phase 2__
-<:chaosroar:994644356671737966> → <:ingen:641339234111848463> + <:zekkil:903244090953588787> <:eofspec:1257438999794946099> → <:havoc:535532879300526080> → <:gfury:535532879334080527> → <:backhandflank:867678153854025779> → <:frag:535541273755385885> → <:dismember:535532879376023572> → <:bloodtendrils:535532854327640064> → <:havoc:535532879300526080> → <:reflect:535541258786177064> → <:smokecloud:856635090641879050> + <:blackstonearrow:785031580149743617> <:grico:787904334812807238> → <:veng:543478434953822208> + <:vitality:654618235097972737> + <:reprisal:513190159462694912> → <:res:535541258844635148> → <:gbarge:535532879250456578> → <:gflurry:535532879283879977> → <:dismember:535532879376023572> → <:havoc:535532879300526080> → equip <:vestmentsofhavochood:994189297659940904> + <:gfury:535532879334080527> → <:anti:535541306475151390> → <:zerk:535532854004678657> → equip <:jawsoftheabyss:947871842595639306> + <:gbarge:535532879250456578> → <:destroy:535532879330148352> → <:sever:535532879577612298> → <:havoc:535532879300526080> → <:backhand:535532854302605333> → stall <:slice:535532879594258432> + run to Nefthys + pre-throw <:vulnbomb:655341074235129858> at 1st Nefthys
+<:smash:535532879820619786> → <:ingen:641339234111848463> + <:zekkil:903244090953588787> <:spec:537340400273195028> → <:sever:535532879577612298> → <:gfury:535532879334080527> → <:backhandflank:867678153854025779> → <:sever:535532879577612298> → <:dismember:535532879376023572> → <:bloodtendrils:535532854327640064> → <:smash:535532879820619786> → <:reflect:535541258786177064> → <:smokecloud:856635090641879050> + <:sever:535532879577612298> → <:veng:543478434953822208> + <:vitality:654618235097972737> + <:reprisal:513190159462694912> → <:res:535541258844635148> → <:gbarge:535532879250456578> → <:gflurry:535532879283879977> → <:dismember:535532879376023572> → <:smash:535532879820619786> → equip <:vestmentsofhavochood:994189297659940904> + <:gfury:535532879334080527> → <:anti:535541306475151390> → <:zerk:535532854004678657> → equip <:jawsoftheabyss:947871842595639306> + <:gbarge:535532879250456578> → <:destroy:535532879330148352> → <:smash:535532879820619786> → <:dragonlongsword:1048592042399383713> <:eofspec:1257438999794946099> → <:sever:535532879577612298> → stall <:slice:535532879594258432> + run to Nefthys + pre-throw <:vulnbomb:655341074235129858> at 1st Nefthys
 
 .
 ⬥ Pray <:soulsplit:615613924506599497> for all 3 hits of Obliterate, <:res:535541258844635148> should heal you on the 2nd hit
-⬥ Last 3 basics after <:destroy:535532879330148352> may not be needed if you phase early
+⬥ This phase is not 100% consistent, it is normal to be 5-10k off phasing before scarabs
 ⬥ Stalled <:slice:535532879594258432> is just to build adren, it is not released on Nefthys
 ⬥ Aim to finish P2 by 1:00
 
 .
 ### __Phase 3__
 
-wait 2t after Nefthys spawn + <:gbarge:535532879250456578> → <:gflurry:535532879283879977> → 3t <:assault:535532855191928842> → <:gfury:535532879334080527> + <:surge:535533810004262912> / <:bd:535532854281764884> to 2nd Nefthys → <:vulnbomb:655341074235129858> + <:havoc:535532879300526080> → <:overpower:535532879334080517> → <:punish:535532879439069184> + <:surge:535533810004262912> to Nakatra → build to 90% adren → <:dba:603979368850653216> <:spec:537340400273195028> → <:blackstonearrow:785031580149743617> <:grico:787904334812807238> → <:dismember:535532879376023572>
-
-⬥ Ending on Nakatra requires some improv. Important to prioritize getting off <:dismember:535532879376023572> with <:jawsoftheabyss:947871842595639306>, <:dba:603979368850653216> <:spec:537340400273195028>, and <:blackstonearrow:785031580149743617> <:grico:787904334812807238>
+wait 2t after Nefthys spawn + <:gbarge:535532879250456578> → <:gflurry:535532879283879977> → 3t <:assault:535532855191928842> → <:gfury:535532879334080527> + <:surge:535533810004262912> / <:bd:535532854281764884> to 2nd Nefthys → <:vulnbomb:655341074235129858> + <:smash:535532879820619786> → <:overpower:535532879334080517> → <:punish:535532879439069184> + <:surge:535533810004262912> to Nakatra → <:dismember:535532879376023572> →  <:chaosroar:994644356671737966> → <:zekkil:903244090953588787> <:spec:537340400273195028> → <:sever:535532879577612298>
 
 .
 ### __Shadowsands__
-<:divert:787904334377648130> + <:surge:535533810004262912> / <:bd:535532854281764884> to Soul Storm → TC 1st <:felineakh:1004107296076480532> + <:sever:535532879577612298> → <:deci:535532879325822986> → TC 2nd <:felineakh:1004107296076480532> + <:cleave:535532878616985610> → <:sever:535532879577612298> → TC <:gorillaakh:1004107294084182017> + <:dismember:535532879376023572> → equip <:vestmentsofhavochood:994189297659940904> + release Soul Fragments
+<:divert:787904334377648130> + <:surge:535533810004262912> / <:bd:535532854281764884> to Soul Storm → TC 1st <:felineakh:1004107296076480532> + <:gfury:535532879334080527> → <:pulverise:535532879053062146> → TC 2nd <:felineakh:1004107296076480532> + 3t <:gflurry:535532879283879977> → <:deci:535532879325822986> → TC <:gorillaakh:1004107294084182017> + <:sever:535532879577612298> + release Soul Fragments + equip <:vestmentsofhavochood:994189297659940904>
 
 ⬥ Spam click Nakatra before getting dragged into Shadowsands in order to retain target
 ⬥ This rotation is given as an example, but will require improv depending on adren. You want to end on at least 100% adren and equip <:vestmentsofhavochood:994189297659940904> before leaving
@@ -69,7 +68,7 @@ wait 2t after Nefthys spawn + <:gbarge:535532879250456578> → <:gflurry:5355328
 
 .
 ### __Phase 4__
-<:anti:535541306475151390> → <:freedom:535541258240786434> → <:vulnbomb:655341074235129858> + <:nip:537336877900890135> + <:gbarge:535532879250456578> → <:bd:535532854281764884> to Hieroglyph + <:zerk:535532854004678657> + <:veng:543478434953822208> → <:limitless:641339233638023179> + <:destroy:535532879330148352> → equip <:jawsoftheabyss:947871842595639306> + <:zemouregalsnexus:1179716261681307728> + stall <:gfury:535532879334080527> → release <:gfury:535532879334080527> + <:backhandflank:867678153854025779> + <:adrenrenewal:736298121704767538> → <:assault:535532855191928842> → <:punish:535532879439069184> → <:havoc:535532879300526080> → <:overpower:535532879334080517> → <:reflect:535541258786177064> → <:chaosroar:994644356671737966> → <:divert:787904334377648130> → <:ingen:641339234111848463> + <:dragonclaw:779048041088024606> <:eofspec:1257438999794946099> → <:dragonclaw:779048041088024606> <:eofspec:1257438999794946099> → improv until dead
+<:anti:535541306475151390> → <:freedom:535541258240786434> → <:vulnbomb:655341074235129858> + <:nip:537336877900890135> + <:gbarge:535532879250456578> → <:bd:535532854281764884> to Hieroglyph + <:zerk:535532854004678657> + <:veng:543478434953822208> → <:limitless:641339233638023179> + <:destroy:535532879330148352> → equip <:jawsoftheabyss:947871842595639306> + <:zemouregalsnexus:1179716261681307728> + stall <:gfury:535532879334080527> → release <:gfury:535532879334080527> + <:backhandflank:867678153854025779> + <:adrenrenewal:736298121704767538> → <:assault:535532855191928842> → <:punish:535532879439069184> → <:smash:535532879820619786> → <:overpower:535532879334080517> → <:reflect:535541258786177064> → <:gfury:535532879334080527> → <:divert:787904334377648130> → <:ingen:641339234111848463> + <:dragonclaw:779048041088024606> <:eofspec:1257438999794946099> → <:dragonclaw:779048041088024606> <:eofspec:1257438999794946099> → improv until dead
 
 ⬥ Assuming you don't lose ticks, you should walk back to dodge the Sanctum Shockwave after <:punish:535532879439069184> and after <:overpower:535532879334080517>
 ⬥ Pray <:deflectmage:544195487926845462> for the 2nd and 3rd hit of Obliterate
@@ -84,7 +83,7 @@ wait 2t after Nefthys spawn + <:gbarge:535532879250456578> → <:gflurry:5355328
     "fields": [
       {
         "name": "__Example Kill__",
-        "value": "⬥ [Grandmaster Speed Killer Example Kill](https://www.youtube.com/watch?v=Ekgr8WYDjHk)"
+        "value": "⬥ [Grandmaster Speed Killer Example Kill](https://www.youtube.com/watch?v=TZO0jJ8dbJE)"
       }
     ]
   }


### PR DESCRIPTION
Updated Nakatra Rotation, per Evil Lucario's video, with the following changes:

- P2 "roar > ezk eof" has been changed to "smash > ezk spec"
- All cases of havoc have been changed to smash
- Note added to P2 that it is no longer 100% consistent
- Added ring of retribution to preset and a note to use on reflects
- Added dlong eof to preset and added in rotation on P2 end
- Changed nak P3 pre-phase to "roar > ezk spec", which also allowed to get rid of dba on prephase and blackstone arrows
- Changed shadowsands rotation to include pulverize