### PR TITLE
Update amascut-2000-mechanics.txt

### DIFF
--- a/rs3-full-boss-guides/amascut/amascut-2000-mechanics.txt
+++ b/rs3-full-boss-guides/amascut/amascut-2000-mechanics.txt
@@ -1,1 +1,224 @@
+# Amascut, God of Destruction 2000%
 .
+.img:https://img.pvme.io/images/S9miXZBbl7.png
+*Note: a **Table of Contents** can be found in the pins.*
+.
+## __Introduction__
+.tag:intro
+This is an early mechanics guide on 2000% Amascut. Beware of mistakes, and expect an update in the near future. Numbers may vary based on team size! If you have suggestions for our guides, post them [here](<https://discord.com/channels/534508796639182860/1020853673317908500>).
+Amascut the Devourer is an endgame group boss encounter, available after completion of the [Eclipse of the Heart](<https://runescape.wiki/w/Eclipse_of_the_Heart>) quest. Normal mode and 100%, 500%, 750%, 1000%, 2000%, and 4000% enrage modes are available. Amascut drops the T95 <:melee:1096130867279171706> halberd [Tumeken's Light](<https://runescape.wiki/w/Tumeken%27s_Light>), the T95 <:necromancy:1148995625896120460> [Devourer's Guard](<https://runescape.wiki/w/Devourer%27s_Guard>), the T95 <:magic:689504724159823906> robes of [Tumeken's Resplendence](<https://runescape.wiki/w/Tumeken%27s_resplendence_equipment>), the [Devourer's Nexus](<https://runescape.wiki/w/The_Devourer%27s_Nexus>), and the [Shard of Genesis Essence](<https://runescape.wiki/w/Shard_of_Genesis_Essence>).
+
+.
+### Amascut 2000% stats
+⬥ 12M <:constitution:689509250887712902>
+⬥ Size: 3x3
+⬥ 95 <:defence:689509250979987525> 2765 armour rating
+⬥ 55 affinity all
+⬥ <:poisonicon:944649693500154006> and <:stunicon:841419289428492369> immune
+⬥ No slayer creature
+
+## __Mechanics__
+.tag:mechs
+**Auto-attacks:**
+⬥ Left hand <:magic:689504724159823906> attack to all players.
+⬥ Right hand <:melee:1096130867279171706> AoE attack on tank that ricochets as <:range:580168050121113623> attacks on the other players.
+⬥ Three rapid <:melee:1096130867279171706> or <:magic:689504724159823906> swipes on the tank. The style depends on her last auto-attack: For example: if it was <:magic:689504724159823906>, the three hits will be <:magic:689504724159823906>.
+⬥ After three autos, Amascut starts a new mechanic at 100% adrenaline.
+
+.
+**Mobs:**
+⬥ Gatekeeper Gorilla Akhs (150k LP). need to be killed to use the gateways.
+⬥ Feline Guard Akhs (25k LP). Will target those carrying a fragment of Tumeken.
+⬥ Volatile Scarab Akhs (2k LP). They need to be stunned <:stunicon:841419289428492369> to take damage, and will explode if left alone.
+⬥ Modest Crocodile Demons (50k LP). When its bar is full, -50% adrenaline gain debuff is applied on the target.
+    • Reflect any damage not taken from an auto-attack, basic ability or conjure
+        ⬩ <:crack4:712073087662686249> and <:as4:712074245202772009> do not reflect.
+⬥ Chainwarden Mage Akhs (130k LP). Protects the chains (50k LP each) beyond the gateways.
+⬥ Explosive Scarabs (5k LP). can be killed and then thrown to remove Carapace. expire over time.
+⬥ Lightstealer Salawa Akh (50k LP). Will target and drain Tumeken's fragment charge.
+⬥ Devourer Mage and Ranger (15k LP). Stand on the platforms, barring you from Tumeken's Light.
+⬥ Shadow of Amascut (150k LP). Deal <:melee:1096130867279171706> damage and can be stunned.
+
+.
+### Debuffs
+**Apmeken's Burden**
+⬥ From Gatekeeper Gorilla Akhs. Deals damage every 1.8s and adds a stack. Can be transferred to teammates. Damage increases every hit, instakill at 8 stacks.
+**Lone Soul**
+⬥ Heal Other <:healother:567727985851891715>, Heal Group, and Intercept <:cept:543478434509357098> are disabled in Hard Mode.
+**Interceptor**
+⬥ Gained upon blocking Amascut's Altar strike. Taking another strike will be an instakill.
+**Corruption**
+⬥ The tank gains one stack of Corruption for every hit received, increasing damage taken. Getting hit by Soulfire waves and Shockwaves also gives Corruption stacks. Max 15 stacks, and stacks expire ~15s after the last one has been given.
+
+.
+### Phase 1 (12,000k)
+⬥ 3 autos → Triple Tap → swipes → 2 autos → Summon Scarabs → 1 auto → swipes → 1 auto → Crushing Soul → 2 autos → swipes → Empowered Eruption → 3 autos → Triple Tap → swipes → 2 autos → phase 2
+
+**Triple Tap**
+⬥ Amascut says `Grovel`, `pathetic` OR `weak` and will launch three projectiles in the air, with each colour corresponding to a combat style (green: <:range:580168050121113623>, blue: <:magic:689504724159823906>, red: <:melee:1096130867279171706>) on the tank. These will hit the tank one tick apart. Use protection prayers <:protectfrommelee:1052551452788269127> <:protectfrommagic:1052551456835768351> <:protectfrommissiles:1052551455078367313>
+.
+**Summon Scarabs**
+⬥ Amascut says `Tear them apart` and summons Volatile Scarab Akhs. They need to be stunned <:stunicon:841419289428492369> to take damage, and will explode if left alone.
+.
+**Crushing Soul**
+⬥ Amascut says `Bend the knee` OR `All strength withers` and deals big typeless damage on the tank. Has defensive penetration. Damage can be shared with nearby teammates (3x3?).
+.
+**Empowered Eruption**
+⬥ Amascut says `I will not suffer this.` OR `Your soul is weak` and the arena turns a certain colour, corresponding to a combat style (green: <:range:580168050121113623>, blue: <:magic:689504724159823906>, red: <:melee:1096130867279171706>). Every player will take three hits from that style and should use protection prayers <:protectfrommelee:1052551452788269127> <:protectfrommagic:1052551456835768351> <:protectfrommissiles:1052551455078367313>
+.
+**Empowered auto**
+⬥ When Amascut does her three rapid <:melee:1096130867279171706> or <:magic:689504724159823906> auto-attacks, Amascut deals another <:magic:689504724159823906> or <:melee:1096130867279171706> hit to the tank, same tick as the third attack. This auto will always be a different style from the original three.
+.
+**Tank pull**
+⬥ Whenever the person with aggro is too far from Amascut, she will say `You dare to turn your back on me?` and drag them before her. This stuns <:stunicon:841419289428492369> and binds <:bindicon:1102897815073603685> you for 3s. Gives adrenaline to Amascut, likely replaces an auto-attack.
+
+.
+### Phase 2
+**Devourer's Destruction**
+Amascut says `ENOUGH! Bring forth Crondis and Apmeken` and a destruction timer of 100.2s starts. When the timer ends, every player is instakilled.
+⬥ Two Gatekeeper gorilla akhs on the sides. They can stun and be stunned/bound. One random player gets marked with the Burden of Amascut. This debuff is a ramping bleed and can be passed to others by standing next to them, resetting the damage. Modest Crocodile Demons spawn at both northern entrances, deal heavy <:range:580168050121113623> and <:magic:689504724159823906> damage, and reflect non-basic ability damage. When their adrenaline bar is full, the target's adrenaline gain is reduced by 50%. Feline Guard Akhs and Lightstealer Salawa Akhs spawn as time progresses.
+
+⬥ After the gatekeeper gorillas are dead, players can go into gateways west and east to free the Echoes of Apmeken and Crondis. Within they will find a Chainwarden Akh and three chains.
+Every killed chain turns the respective statue yellow instead of green. A player in the main arena cleanses the corrupted statue every time, permanently killing the chain. Clicking the statue early deals damage. Chains respawn over time if the statue is not cleansed within ~12s. After all three chains are broken and cleansed, the player inside the respective room can liberate the god and receive their fragment of Tumeken (30s timer). Bringing the blessing to the statue stuns Amascut for 25s. You cannot use <:surge:535533810004262912> or <:dive:1049378668197195808> during this, but <:prismofsalvation:892342109431029761> does work. The stuns of both blessings stack, and after they end phase 3 starts.
+
+**Empowered Soulfire**
+⬥ During phase 2 the main arena gets waves of corruption passing over it, south to north. Along the Chains, Empowered Soulfire will also appear. These deal magic damage. <:devo:513190158728953857> blocks damage, but duration is reduced by 3s for each hit. Each hit taken gives one Corruption stack.
+
+.
+### Phase 3 (`Ugh... No!`)
+⬥ Similar to phase 1, but includes Devourer's Shockwave with every mechanic.
+⬥ Rotation:
+33% adren no auto → swipes 3<:magic:689504724159823906>1<:melee:1096130867279171706> → <:melee:1096130867279171706> → Triple Tap → <:melee:1096130867279171706> → <:melee:1096130867279171706> → swipes 3<:melee:1096130867279171706> 1<:magic:689504724159823906> → Summon Scarabs → 3x <:magic:689504724159823906> → Triple Tap → swipes 3<:magic:689504724159823906>1<:melee:1096130867279171706> → <:magic:689504724159823906> → <:magic:689504724159823906> → Empowered Eruption → <:magic:689504724159823906> → swipes 3<:magic:689504724159823906>1<:melee:1096130867279171706> → <:melee:1096130867279171706> → Triple Tap → <:melee:1096130867279171706> → <:melee:1096130867279171706> → swipes 3<:melee:1096130867279171706>1<:magic:689504724159823906> → phase 4.
+
+**Devourer's Shockwave**
+Amascut concentric shockwaves spread from under her outward.
+⬥ The pattern is always the same:
+    • First only a "middle" ring of 3 tiles wide. MD is safe, far range is safe.
+    • Second are three consecutive shockwaves moving from inner to outer.
+        ⬩ Inner (9x9 including under Amascut)
+        ⬩ Middle (ring of 3 tiles wide)
+        ⬩ Outer (ring of 6 tiles wide).
+⬥ Deals typeless damage, resets defensives, and puts them on a 6s cooldown. When hit, adds 1 corruption stack.
+
+.
+### Phase 4
+**Devourer's Destruction**
+Amascut says `Scabaras...Het... Bear witness!` and the destruction timer starts again similar to phase 2.
+⬥ Players can go into gateways west and east to free the Echoes of Het and Scabaras after killing the Gatekeeper gorilla akhs. No modest crocodiles spawn.
+
+**Scarab bombs**
+⬥ Explosive Scarab Akhs spawn in the arena.
+    • Scarabs will not spawn on players in a 3x3 area (can use <:dive:1049378668197195808> to stop spawns).
+⬥ Every non-scarab mob NPC has a carapace that makes them immune to damage. Remove the carapace by killing and grabbing Explosive Scarab Akhs, then throwing Scarabs to the NPC and through the gateways. Weaken and kill the Gatekeeper Gorilla Akhs. You need 4 Scarabs per gateway for the Chainwarden Akh and the three chains. Scarab throwing has unlimited attack range but does require line-of-sight. Alive Explosive Scarab Akhs heal Amascut over time (100 LP/Scarab/1.2s). Dead Scarabs explode over time and deal minor typeless damage to all players in the arena.
+
+.
+### Phase 5 Tumeken's Reformation
+**Charging the fragment of Tumeken**
+⬥ Amascut says `Tumeken's heart. Delivered to me by these mortals` and four fragments shoot out of each statue, and Tumeken appears in the middle.
+⬥ Two Soul Obelisks appear west and east with 30k out of 50k <:constitution:689509250887712902>, and at full health they will deal damage to all players.
+    • Keep their health below 50k. Soul obelisks stop healing when taking damage.
+⬥ Channel statue energy to the fragments by having one or multiple players link energy from the statue to the fragment.
+.
+**Altar Strike**
+⬥ Amascut will say `your light will be snuffed out, once and for all` strike the fragments via the altars/statues, draining them of charge.
+.
+**Interception**
+⬥ Have a player stand on the green line to intercept Amascut's attack. All lines can be blocked simultaneously by standing in front of Amascut. Taking two hits in a row is an instakill (Interceptor debuff), so switch out with your teammates. Lightstealer Salawa Akhs will continuously spawn from the southern stairs and drain charge from the fragments of Tumeken if reached.
+.
+**Blinking Strike**
+⬥ After a fragment is fully charged, Reform Tumeken in the centre and Amascut will become attackable again. She will start dashing and attacking the Reformed Tumeken four times saying `GET OUT OF MY WAY!``I AM.` `THE GOD.` `OF.` `DESTRUCTION`. If not intercepted by the player called by Tumeken `(name) shield us from her shadow…` the attack will hit all players for heavy damage, and reduce reform progress by 27(?). The intercept damage has 10% <:defence:689509250979987525> penetration and ricochets to another player. After the four attacks, more fragments have to be charged if progress has not reached 100. For every fragment charged, progress increases by 1 every 1.2s. Every Lightstealer Salawa Akh that explodes near Tumeken will remove 4 reform progress. If progress ever drops under 0, every player is instakilled.
+⬥ Amascut transitions to phase 6 at 100% reform progress.
+⬥ Amascut's health caps at 1800k <:constitution:689509250887712902>
+
+.
+### Phase 6
+Amascut says Amascut says `I will not be denied!`  and `Mwuahahaha` and an Engulfing Shadow spawns on Tumeken.
+**Engulfing shadow & Shadow fragments**
+⬥ This Shadow has 500k <:constitution:689509250887712902> and is attackable. Amascut will start charging a 500k black health bar. The engulfing shadow and Amascut's health bar gain 1% LP based on the Engulfed Shadow's remaining lifepoints. Engulfing Shadow tears will appear, healing the Shadow for 1ks rapidly and 15k if not absorbed. After absorbing tears, a green bar fills up exploding on you for typeless damage (~800 per tear?).
+.
+**Soul Flare**
+Amascut will make it rain, with 8 3x3 projectiles landing across the arena. These deal massive typeless damage.
+.
+**Platform Collapse**
+⬥ A Collapse countdown of 24s starts, when the timer runs out, the jumper is instakilled.<:instakill:1104794644497309809>. Tumeken names one player (referred to as Jumper), and that player can take the path of Tumeken to a platform on the west or east and kill the Devourer minions, moving to the next platform every time.
+⬥ The Countdown can get paused temporarily by having another player stand on the same symbol as the jumper is on. This symbol will light up when stood upon. After killing all Devourers, the Jumper gains Tumeken's light (5x5 area surrounding them). The Jumper reenters the arena, and the Engulfed Shadow stops. Amascut says `I WILL NOT BE SUBJUGATED BY A MORTAL!`.
+
+**Shadows of Amascut**
+⬥ Amascut says `fall to the shadow` and Shadows of Amascut appear that need to be killed, one for each player not tanking Amascut. The shadows deal <:melee:1096130867279171706> damage.
+⬥ Shadows of amascut have a buff when close together Soul Link, and can hit through <:devo:513190158728953857>.
+⬥ Amascut will use auto-attacks as before, but only 20% adrenaline per auto.
+    • Amascut Rotation: 20% start → swipes → 3 mage autos → Soul Prison → swipes → 4 melee autos → Soul Prison
+.
+**Soul Prison**
+When Amascut says `Your companions will betray you, as they always do.`
+⬥ A green bar starts on one player and gradually appears on all players with a Shadow attacking them.
+    • When the green bar on the player is full, you get <:defence:689509250979987525> penetration typeless damage (12k). Stand in the Tumeken's Light area of the Jumper to avoid the damage.
+    • Green bars also fill on the Shadows after the first one dies. These reset when another Shadow is killed.
+    • When a second Soul Flare happens, all players will get the green bar at the same time.
+⬥ Killing all shadows stuns Amascut for 25s, allowing you to DPS down the black health bar. Can continue DPS on her true health bar after.
+⬥ After the stun all remaining health will be dealt as damage to the team in rapid succession.
+⬥ Amascut's true health caps at 600k <:constitution:689509250887712902>
+
+.
+### Phase 7
+Amascut says `YOU ARE NOTHING` and teleports everyone to the throne room (27x27 tiles, or 9 "9x9" sections).
+⬥ Tumeken is directly north, Apmeken's altar northwest, Scabaras' northeast, Crondis' southeast, and Het's southwest. She gains the Inner Darkness buff, meaning she will take reduced damage from all sources not blessed by the Light Within buff.
+
+*Notes: Amascut stands one tile north of centre.
+⬥ Every <:magic:689504724159823906> auto-attack gives every player 1 corruption stack.
+⬥ Tumeken has 400k health. When he dies, everyone gets instakilled.
+⬥ EZK's Flamebound Rival <:ezk:903244090953588787> <:spec:537340400273195028> and storm shards <:stormshards:536256663641128971> remain during phase transition to P7.
+⬥ Taking a typeless Hieroglyph or Shockwave hit deals 4k <:range:580168050121113623> damage to Tumeken per player hit.*
+
+Rotation:
+Starts at 66% adrenaline → 4 <:magic:689504724159823906> autos → 4.8s charge → Tumeken Strike
+
+.
+**Tumeken Strike**
+⬥ Amascut will address one of the lesser gods by name and try to strike at Tumeken.
+    • Crondis: `Crondis. It should  have never come to this.`
+    • Scabaras: `Scabaras...`
+    • Apmeken: `I am sorry Apmeken.`
+    • Het: `Forgive me, Het.`
+⬥ Tumeken will aid the called god's altar to bear the brunt of the strike. Provoke <:voke:535541259465392143> Amascut so she faces towards the called altar. This will let the attack on you ricochet to the altar and send Tumeken's light back at Amascut, stunning her.
+
+.
+__When done wrong__
+Amascut says `Heh Heergh` or `Hmmmwuahaha`, Tumeken takes 200k damage, and the party takes massive typeless <:defence:689509250979987525> penetrating damage. 16 engulfing shadow tears appear, healing Amascut 1k each every tick.
+    • Fail rotation: Tumeken Strike → 3 <:magic:689504724159823906> autos → Soul Crush → 3 <:magic:689504724159823906> autos → repeat
+
+.
+__When done right__
+⬥ Tumeken takes a small hit (12.5k), Amascut says `This cannot be the end...`, all players get the Light Within buff for 30s and Amascut gets stunned for ~7s. After this, Amascut will use Empowered Eruptions alongside Empowered Shockwaves or Empowered Hieroglyphs. After Light Within has expired, Amascut will repeat Tumeken Strike.
+⬥ An effect dependent on the god is applied.
+    • Apmeken: A random player gets Apmeken's Burden debuff.
+    • Scabaras: Explosive scarabs spawn. kill, grab and throw multiple to break Amascut's Carapace.
+        ⬩ Requires 3+ scarabs. Click on her centre tile, not (through) her model!
+    • Crondis: Two Modest crocodiles spawn in; one southwest and one northeast.
+    • Het: Healing through Strength. Heals Amascut for ~30% based on damage dealt.
+
+**Empowered Shockwaves**
+⬥ Four versions have been observed:
+    • Inner area is safe (9x9)
+    • Middle ring is safe, 3 tiles wide (5 tiles from Amascut)
+    • Far-middle ring is safe, 3 tiles wide (8 tiles from Amascut)
+    • Outer ring is safe, 3 tiles wide
+.
+**Empowered Hieroglyphs (after Apmeken)**
+⬥ Similar to the Nakatra fight, various 9x9 sections of the arena will glow blue and blow up. She divides the arena in 9 sections, of which 3-8 sections are about to be blasted. Getting hit resets defensive cooldowns.
+
+.
+## __Example kills__
+.tag:example
+⬥ [Evil Lucario's World's First POV](https://www.youtube.com/watch?v=1fntOvpGlc8)
+
+.
+{
+  "embed": {
+    "title": "__Table of Contents__",
+    "description": "*To edit this guide in our web editor [click here](<https://pvme.io/guide-editor/?id={{channel:id}}>), or visit <id:customize> and select Entry Editor*\n⬥ [Introduction]($linkmsg_intro$)\n⬥ [Mechanics]($linkmsg_mechs$)\n⬥ [Example kills]($linkmsg_example$)",
+    "color": 39423
+  }
+}
+.embed:json
+.pin:delete


### PR DESCRIPTION
githubbed

added details:
Add crackling and aftershock as things that don’t reflect to croc p3 shockwave. outer ring is 6 tiles wide
p4: if you dive near to scarab spawn points, they do not spawn (3x3 around you?) p5: soul obelisks stop healing when taking damage (DoT angle) ezk spec and storm shards stick p6->p7
p7: taking a typeless hieroglyph or shockwave hit deals 4000 ranged damage to Tumeken per player hit shadows of amascut can hit through devo

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
