### PR TITLE
Update relic.txt

### DIFF
--- a/commands/relic.txt
+++ b/commands/relic.txt
@@ -21,7 +21,7 @@
       },
       {
         "name": "__Filler Relics__",
-        "value": "⬥ <:fontoflife:698225967679930408> [Font of Life](https://runescape.wiki/w/Font_of_Life) (50)\n⬥ <:shadowsgrace:895999229737185280> [Shadow's Grace](https://runescape.wiki/w/Shadow's_Grace#Obtaining) (50)",
+        "value": "⬥ <:fontoflife:698225967679930408> [Font of Life](https://runescape.wiki/w/Font_of_Life) (50)\n⬥ <:shadowsgrace:895999229737185280> [Shadow's Grace](https://runescape.wiki/w/Shadow's_Grace#Obtaining) (50)\n⬥ <:hungrylikethewolf:1516269344106086492> [Hungry Like the Wolf](https://runescape.wiki/w/Hungry_Like_the_Wolf#Obtaining) (100)",
         "inline": true
       },
       {


### PR DESCRIPTION
Submitted from the PvME Guide Editor.

Guide file: `commands/relic.txt`
Submitted by: Porfet
GitHub user: `Porfet` (174056323)

Update summaries:
1. changing place of wolf relic to be on the left

This automated submission updates one existing guide file only.