### PR TITLE
Clarify Undead Slayer task depletion status

### DIFF
--- a/rs3-full-boss-guides/rise-of-the-six/rise-of-the-six-solo.txt
+++ b/rs3-full-boss-guides/rise-of-the-six/rise-of-the-six-solo.txt
@@ -38,6 +38,7 @@ This guide assumes you understand the basics of combat, equipment, and the RotS 
 ⬥ You are required to have these buffs for this rotation to work:
     • Undead Slayer ability <:undeadslayer:641339922019516416> and Undead Slayer perk <:undeadslayerperk:689502804720615441>
     • Undead Slayer task (reduced to 1) alongside Genocidal perk <:genocidal:689503091539705870>
+        ⬩ Task will not deplete
     • Fort Forinthry Guardhouse Slayer Upgrades
     • Ghost Hunter Helm, Backpack, Legs <:ghosthunterhelm:855865893808767016> <:ghosthunterbag:855865893829476352> <:ghosthunterlegs:855865893854511144> and Salve Amulet <:salveamulet:797899945730244648>
     • Equilibrium perk <:eq4:712073088589627505>
@@ -81,6 +82,7 @@ This guide assumes you understand the basics of combat, equipment, and the RotS 
 ⬥ You are required to have these buffs for this rotation to work:
     • Undead Slayer ability <:undeadslayer:641339922019516416> and Undead Slayer perk <:undeadslayerperk:689502804720615441>
     • Undead Slayer task (reduced to 1) alongside Genocidal perk <:genocidal:689503091539705870>
+        ⬩ Task will not deplete
     • Fort Forinthry Guardhouse Slayer Upgrades
     • Ghost Hunter Helm, Backpack, Legs <:ghosthunterhelm:855865893808767016> <:ghosthunterbag:855865893829476352> <:ghosthunterlegs:855865893854511144> and Salve Amulet <:salveamulet:797899945730244648>
     • Equilibrium perk <:eq4:712073088589627505> and Ultimatums perk <:ultimatums4:1478090603026710648>


### PR DESCRIPTION
Added note that the Undead Slayer task will not deplete during the rotation.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
