### PR TITLE
hm zuk melee-ranged readd missing part of guide

### DIFF
--- a/rs3-full-boss-guides/tzkal-zuk/hm-zuk-melee-ranged.txt
+++ b/rs3-full-boss-guides/tzkal-zuk/hm-zuk-melee-ranged.txt
@@ -63,3 +63,232 @@ As such, it is strongly recommended to follow the guide alongside the video exam
 ### Wave 3
 **General pointers**
 ⬥ Set up <:gdeathsswift:994644354536837121> + <:imbueshadows:1478061866193518744>, clear all Yt-Mejkot with <:decimation:643848618477879328> <:eofspec:1257438999794946099> + <:deadshot:1478061860371828929>, then pick off remaining enemies with single-target abilities
+    • Entering the next wave is somewhat timelocked to <:berserk:535532854004678657> cooldown, so there is some amount of leeway on this wave
+.
+**Specific rotations**
+.
+⬥ (1) Zuk: <:deathsporearrows:900758234527301642> <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636> → <:gdeathsswift:994644354536837121> → <:imbueshadows:1478061866193518744> → <:decimation:643848618477879328> <:eofspec:1257438999794946099>
+    • A Wall of Flame will occur around this time, make sure that all Yt-Mejkot have walked around any obstacles before moving away
+⬥ (2) Center-Most Yt-Mejkot: <:fularrow:971025696958853180> <:piercingshot:1478061863723073636> → <:deadshot:1478061860371828929>
+⬥ Remaining Enemies: Pick off using <:bolg:994189289623662702> <:spec:537340400273195028> / <:snapshot:1478061855732666439> / <:shadowtend:642713547142332416> → end on 100 adren
+
+.img:https://img.pvme.io/images/HytPNxCaD4.png
+.
+### Wave 4 (Igneous wave)
+**General pointers**
+⬥ For the sake of consistency, all igneous waves are handled the exact same throughout this guide. Rotations assume <:vulnbomb:655341074235129858> is being used on all three igneous enemies.
+.
+**Specific rotations**
+.
+⬥ (1) Igneous Mej: <:berserk:535532854004678657> + <:adrenrenewal:736298121704767538> → <:gbarge:535532879250456578> → <:gflurry:535532879283879977> → <:gfury:535532879334080527> → wait 2-3 ticks + <:surge:535533810004262912> to Igneous Xil
+    • Wait for <:gflurry:535532879283879977> to finish it since the <:surge:535533810004262912> will cause you to lose line-of-sight
+⬥ (2) Igneous Xil: <:meteorstrike:1478070401702821938> → <:cane:535532878969438210> → basic if needed
+⬥ (3) Igneous Hur: <:backhand:535532854302605333> → <:overpower:535532879334080517> → <:chaosroar:1478062908767211640> if needed
+    • The basic to finish both Xil and Hur can be consistently skipped with an active <:scriptureofful:902209626412560395> proc
+⬥ (4) Zuk: <:chaosroar:1478062908767211640> + <:ezk:903244090953588787> <:spec:537340400273195028> → <:gflurry:535532879283879977>
+
+.img:https://img.pvme.io/images/zK0l97w0ME.png
+.
+### Wave 5 (Challenge wave)
+
+⬥ Step between two Hurs + <:tumekenslight:1400511651014250596> <:spec:537340400273195028> → <:dive:1049378668197195808> between remaining three + <:dragon2hsword:1048592040507744257> <:eofspec:1257438999794946099>
+    • See example video for specific positioning
+
+.
+### Wave 6
+.tag:rangewaves
+**General pointers**
+⬥ Set up <:gdeathsswift:994644354536837121> + <:bolg:994189289623662702> <:spec:537340400273195028> + <:imbueshadows:1478061866193518744> on Zuk + northern Xil, go all the way south to clear the Jad, then clear remaining mobs with <:decimation:643848618477879328> <:eofspec:1257438999794946099>
+.
+**Specific rotations**
+.
+⬥ (1) Zuk + North Xil: <:deathsporearrows:900758234527301642> <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636> → <:gdeathsswift:994644354536837121> → <:bolg:994189289623662702> <:spec:537340400273195028>
+    • Move further south once Xils spawn to prevent the north-west one from getting stuck
+⬥ (2) Jad: <:imbueshadows:1478061866193518744> → <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:grico:787904334812807238> + <:surge:535533810004262912> through to south wall → <:rapid:535541270521708566> → <:sgb:626466665848242186> <:eofspec:1257438999794946099>
+⬥ (3) Southern-most Xil: <:surge:535533810004262912> + <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:deadshot:1478061860371828929>
+    • The exact Xil to be targeted is usually the one that took 1-2 hits from the end of <:rapid:535541270521708566>
+    • If done correctly the <:deadshot:1478061860371828929> should clear all remaining enemies, otherwise usually one Yt-Mejkot should be finished with <:snapshot:1478061855732666439> + <:shadowtend:642713547142332416>
+
+.
+.img:https://img.pvme.io/images/WIMjU3w6Cq.png
+.
+### Wave 7
+**General pointers**
+⬥ Set up <:meteorstrike:1478070401702821938> + <:berserk:535532854004678657> while clearing northern enemies, <:overpower:535532879334080517> the Yt-Mejkot, then run around to clear remaining enemies
+.
+**Specific rotations**
+.
+⬥ (1) North Mej: s<:meteorstrike:1478070401702821938> / any basic → release when Mej spawns + clear with basics
+⬥ (2) West Xil: <:berserk:535532854004678657> + <:cane:535532878969438210>
+⬥ (3) East Xil: <:gfury:535532879334080527> → <:adaptivestrike:1478062906057949417>
+    • Kihs should be taken out by <:tumekenslight:1400511651014250596> splash damage by the end of the wave, just ignore
+⬥ Center Yt-Mejkot: <:overpower:535532879334080517>
+⬥ (4) East Tok-Xil: <:chaosroar:1478062908767211640> → <:varanussmercy:1448697873603498045> <:eofspec:1257438999794946099>
+⬥ Center 2x Xils: <:rend:1478166426190741584> → <:cane:535532878969438210>
+⬥ West Tok-Xil: <:overpower:535532879334080517>
+
+.img:https://img.pvme.io/images/eA7WlsHyib.png
+.
+### Wave 8
+**General pointers**
+⬥ Clear out northern enemies while clumping southern spawns up, then clear with <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:deadshot:1478061860371828929>
+.
+**Specific rotations**
+.
+⬥ (1) Zuk: <:deathsporearrows:900758234527301642> <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636> → <:gdeathsswift:994644354536837121>
+⬥ (1) North Xil: <:fularrow:971025696958853180> <:bolg:994189289623662702> <:spec:537340400273195028> → <:imbueshadows:1478061866193518744>
+⬥ (2) North-west Tok-Xil: <:rapid:535541270521708566>
+⬥ (2) 2x Mej: <:snipe:1478061857486143498> → <:shadowtend:642713547142332416>
+⬥ (3) North-east Tok-Xil: <:galeshot:1478061864943616122> → <:snapshot:1478061855732666439> → <:grico:787904334812807238>
+⬥ (3) Center-most Tok-Xil: <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:deadshot:1478061860371828929>
+
+.img:https://img.pvme.io/images/TYzqggahJa.png
+.
+### Wave 9 (Igneous wave)
+**General pointers**
+⬥ Same as previous, end with <:chaosroar:1478062908767211640> → <:ezk:903244090953588787> <:spec:537340400273195028> → <:gflurry:535532879283879977> → <:gfury:535532879334080527> on <:tzkalzuk:931175752651653121>
+.img:https://img.pvme.io/images/zK0l97w0ME.png
+.
+### Wave 10 (Challenge wave)
+⬥ <:overpower:535532879334080517> (w/ <:gfury:535532879334080527> should guarantee kill)
+
+.
+### Wave 11
+.tag:magewaves
+**General pointers**
+⬥ Set up <:gdeathsswift:994644354536837121> and pick off initial set of spawns, lure Jads + stragglers to center and clear with <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:rapid:535541270521708566> → <:deadshot:1478061860371828929>
+.
+**Specific rotations**
+.
+⬥ (1) Zuk + North Mej: <:deathsporearrows:900758234527301642> <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636> → <:gdeathsswift:994644354536837121> → <:fularrow:971025696958853180> <:bolg:994189289623662702> <:spec:537340400273195028>
+⬥ South Kih: <:shadowtend:642713547142332416>
+⬥ (2) South-west Kih: <:imbueshadows:1478061866193518744> + <:snapshot:1478061855732666439>
+⬥ (2) South-west Mej: <:snipe:1478061857486143498>
+⬥ (2) South Yt-Mejkot: <:galeshot:1478061864943616122> → <:snapshot:1478061855732666439> → <:grico:787904334812807238>
+⬥ (3) South Mej: <:snapshot:1478061855732666439>
+⬥ (3) Center Jad: <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:rapid:535541270521708566> → <:deadshot:1478061860371828929>
+    • Jad lure may be tricky depending on how you move from (2) to (3), walk halfway then <:surge:535533810004262912> the rest should keep them in <:decimation:643848618477879328> range
+    • The two remaining Mej should be caught in the AoE as well, otherwise finish with <:snapshot:1478061855732666439>
+.img:https://img.pvme.io/images/V7QYkMcd7p.png
+.
+### Wave 12
+**General pointers**
+⬥ <:meteorstrike:1478070401702821938> North Kih, <:berserk:535532854004678657> to clear out east and southern enemies, then AoE the remainder in the center
+.
+**Specific rotations**
+.
+⬥ (1) North Kih: s<:meteorstrike:1478070401702821938> on Zuk → release with basic to kill
+⬥ (2) East Tok-Xil: <:berserk:535532854004678657> → <:overpower:535532879334080517>
+⬥ (2) East Mej: <:gfury:535532879334080527> → <:rend:1478166426190741584>
+⬥ South Kih: <:tumekenslight:1400511651014250596> <:spec:537340400273195028>
+⬥ (3) West Mej: <:pulverise:535532879053062146>
+⬥ Center Tok-Xil: <:overpower:535532879334080517>
+⬥ North-west Ket + Mej: <:chaosroar:1478062908767211640> + <:cane:535532878969438210>
+⬥ Center Ket + Mej: <:dragon2hsword:1048592040507744257> <:eofspec:1257438999794946099>
+    • AoE + <:tumekenslight:1400511651014250596> damage should clear out all enemies, finish stragglers off with <:range:580168050121113623> basics if not
+
+.img:https://img.pvme.io/images/lLg3mjHAbK.png
+.
+### Wave 13
+**General pointers**
+⬥ Set up <:gdeathsswift:994644354536837121>, clear both Tok-Xils, then group up remaining enemies to <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:deadshot:1478061860371828929>
+.
+**Specific rotations**
+.
+⬥ (1) Zuk + North Tok-Xil: <:deathsporearrows:900758234527301642> <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636> → <:gdeathsswift:994644354536837121> → <:fularrow:971025696958853180> <:bolg:994189289623662702> <:spec:537340400273195028> → <:imbueshadows:1478061866193518744>
+⬥ East Mej: <:galeshot:1478061864943616122> → <:snapshot:1478061855732666439>
+⬥ South Tok-Xil: <:rapid:535541270521708566> (cancel once low enough) → <:grico:787904334812807238>
+⬥ (2) South-west Ket: <:snipe:1478061857486143498> → <:shadowtend:642713547142332416>
+⬥ (3) Center-most Ket: <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:surge:535533810004262912> / <:dive:1049378668197195808> to get line-of-sight on all enemies → <:deadshot:1478061860371828929> → <:snapshot:1478061855732666439> any stragglers
+.img:https://img.pvme.io/images/7qh8IA13I2.png
+.
+### Wave 14 (Igneous wave)
+**General pointers**
+⬥ Same as previous, stay on melee when Zuk is cleared for <:meteorstrike:1478070401702821938> adren
+
+.img:https://img.pvme.io/images/zK0l97w0ME.png
+.
+### Wave 15 (Challenge wave)
+
+⬥ <:res:535541258844635148> → <:cade:535541306353778689> → <:adaptivestrike:1478062906057949417> let meteor tick up to at least 70 adren → <:deathsporearrows:900758234527301642> <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636>
+
+.
+### Wave 16 (Triple Jad)
+**General pointers**
+⬥ Similar to double Jad lure, let them clump up middle, then clear with <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:rapid:535541270521708566> → <:deadshot:1478061860371828929>
+.
+**Specific rotations**
+.
+⬥ (1) Zuk: <:gdeathsswift:994644354536837121> → <:bolg:994189289623662702> <:spec:537340400273195028> + <:surge:535533810004262912> + <:dive:1049378668197195808> all the way south-west
+⬥ (3) Jad: once lured <:decimation:643848618477879328> <:eofspec:1257438999794946099> → <:rapid:535541270521708566> → <:deadshot:1478061860371828929>
+    • Use <:disrupt:535614336207552523> / <:powerburstofvitality:654618235097972737> if attacks overlap
+.img:https://img.pvme.io/images/V7QYkMcd7p.png
+.
+### Wave 17 (Har-aken)
+.tag:aken
+.img:https://img.pvme.io/images/n4B2Z2KLAw.png
+.
+⬥ Zuk <:meteorstrike:1478070401702821938> → s<:adaptivestrike:1478062906057949417> → <:berserk:535532854004678657>
+⬥ Har-Aken: <:dive:1049378668197195808> + <:gbarge:535532879250456578> → <:overpower:535532879334080517> → <:assault:535532855191928842> → <:varanussmercy:1448697873603498045> <:eofspec:1257438999794946099> → <:rend:1478166426190741584> → <:cane:535532878969438210> → <:overpower:535532879334080517> → <:lengmh:883134308146098227> <:spec:537340400273195028> → <:punish:535532879439069184>
+
+.
+## __Wave 18 (Tz-Kal Zuk)__
+.tag:zuk
+### Zuk
+⬥ Start near the middle and build to 100% adren
+⬥ Equip <:reaverring:839903943018283050> + Apply <:vulnbomb:655341074235129858> + <:smokecloud:856635090641879050> + build <:deathsporearrows:900758234527301642> with <:piercingshot:1478061863723073636> → <:grico:787904334812807238> → <:piercingshot:1478061863723073636> + be on 3-7 <:perfectequilibrium:1006119102814887957>
+
+⬥ Zuk: 3 ticks after <:tzkalzuk:931175752651653121> starts moving <:gdeathsswift:994644354536837121> → <:imbueshadows:1478061866193518744> → <:chaosroar:1478062908767211640> → <:ezk:903244090953588787> <:spec:537340400273195028> → <:bolg:994189289623662702> <:spec:537340400273195028> → <:ecb:615618531937222657> <:eofspec:1257438999794946099> → <:galeshot:1478061864943616122> → <:grico:787904334812807238> → <:rapid:535541270521708566> → <:sgb:626466665848242186> <:eofspec:1257438999794946099> → <:deadshot:1478061860371828929> → <:gloomfirebow:1446178203608809472> <:eofspec:1257438999794946099> → <:snapshot:1478061855732666439> → <:shadowtend:642713547142332416> → <:snipe:1478061857486143498> → <:ecb:615618531937222657> <:eofspec:1257438999794946099> → <:galeshot:1478061864943616122> → <:grico:787904334812807238> + <:disrupt:535614336207552523> → <:rapid:535541270521708566> → <:bolg:994189289623662702> <:spec:537340400273195028> → dump adren to finish
+    • <:surge:535533810004262912> / <:dive:1049378668197195808> as necessary to deal with mechanics
+    • Zuk should be lowered to ~220k or less by this point
+
+.
+### Pizza
+⬥ Igneous Hur: <:bindingshot:535541306563231790> + build <:deathsporearrows:900758234527301642> while killing → <:naturalinstinct:535541258131865633> + <:dba:603979368850653216> when rain is about to disappear
+⬥ Igneous Xil: <:surge:535533810004262912> + <:dive:1049378668197195808> + <:piercingshot:1478061863723073636> → <:snapshot:1478061855732666439> + build adren while killing
+⬥ Igneous Mej: <:surge:535533810004262912> + <:dive:1049378668197195808> + <:grico:787904334812807238> → swap to <:melee:1096130867279171706> and finish with basics
+⬥ Zuk: s<:meteorstrike:1478070401702821938> → r<:meteorstrike:1478070401702821938> + <:adaptivestrike:1478062906057949417> → <:chaosroar:1478062908767211640> / <:rend:1478166426190741584> (depending on his remaining hp) → <:berserk:535532854004678657> → <:ezk:903244090953588787> <:spec:537340400273195028> → <:punish:535532879439069184> if needed
+    • Time it such that the extra action button to interrupt Zuk is usable after <:berserk:535532854004678657>
+
+.
+### Conduits
+⬥ Some improvisation may be needed, but generally just keep pressing strong abilities while following the listed defensive order
+
+.
+⬥ Deal with Zuk's charged attacks using the following:
+    • C1 → <:disrupt:535614336207552523>
+    • C2 → <:res:535541258844635148>
+    • C3 → <:powerburstofvitality:654618235097972737>
+    • C4 → <:rod:513190159462825984> (make sure sign is not available, unequip cape if needed)
+
+⬥ Conduits: <:anti:535541306475151390> → wait 2 ticks + <:gbarge:535532879250456578> → <:gflurry:535532879283879977> → <:gfury:535532879334080527> → <:overpower:535532879334080517> → <:chaosroar:1478062908767211640> / <:rend:1478166426190741584> → <:varanussmercy:1448697873603498045> <:eofspec:1257438999794946099> → <:cane:535532878969438210> → <:res:535541258844635148> / <:disrupt:535614336207552523> → <:lengmh:883134308146098227> <:spec:537340400273195028> → <:overpower:535532879334080517> → equip <:rod:513190159462825984> + improvise to finish, use <:gflurry:535532879283879977> if it comes up while <:berserk:535532854004678657> is still running
+    • Take advantage of the lack of bombs during Zuk's charging attack to use more channelled abilities (<:assault:535532855191928842> / <:gflurry:535532879283879977>)
+
+.
+## __Example videos__
+.tag:example
+⬥ [Full Kill (Biting)](<https://youtu.be/UfvmMGzttbw>)
+⬥ [Full Kill (Equilibrium)](<https://youtu.be/cNhJ15iZE1s>)
+
+.
+{
+  "embed": {
+    "title": "__Table of Contents__",
+    "color": 39423,
+    "description": "*To edit this guide in our web editor [click here](<https://pvme.io/guide-editor/?id={{channel:id}}>), or visit <id:customize> and select Entry Editor*",
+    "fields": [
+      {
+        "name": "__Overview__",
+        "value": "⬥ [Introduction]($linkmsg_intro$)\n⬥ [Loadout]($linkmsg_preset$)",
+        "inline": true
+      },
+      {
+        "name": "__The Fight__",
+        "value": "⬥ [Waves 1-5]($linkmsg_meleewaves$)\n⬥ [Waves 6-10]($linkmsg_rangewaves$)\n⬥ [Waves 11-16]($linkmsg_magewaves$)\n⬥ [Wave 17 (Har-Aken)]($linkmsg_aken$)\n⬥ [Waves 18 (Tz-Kal Zuk)]($linkmsg_zuk$)\n⬥ [Example videos]($linkmsg_example$)",
+        "inline": true
+      }
+    ]
+  }
+}
+.embed:json
+.pin:delete


### PR DESCRIPTION
Expanded detailed strategies and rotations for waves 3 to 18 of the TzKal-Zuk fight, including specific ability usage and general pointers for each wave.

# PvME Change Submission
Thank you for helping maintain our resources! Below is a quick sanity checklist that helps make sure we can keep track of what is changing. Please fill it out :)

## __Sanity Checks__
- [x] - The title of this pull request clearly describes the change I would like to make.
- [x] - If there are multiple changes in this pull request, they are all related.
- [x] - I have tried to write clear a commit message(s) that describes the changes I made.
